### PR TITLE
refactor: optimize framer-motion and perceived performance

### DIFF
--- a/apps/web/src/components/analytics/cookie-banner.tsx
+++ b/apps/web/src/components/analytics/cookie-banner.tsx
@@ -1,6 +1,6 @@
 import { usePostHog } from '@posthog/react';
 import { Button } from '@xbrk/ui/button';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, m } from 'framer-motion';
 import { Cookie, X } from 'lucide-react';
 import { useState } from 'react';
 
@@ -21,7 +21,7 @@ export function CookieBanner() {
   return (
     <AnimatePresence>
       {consentGiven === 'pending' && (
-        <motion.div
+        <m.div
           animate={{ y: 0, opacity: 1 }}
           className="fixed inset-x-0 bottom-0 z-50 p-4"
           exit={{ y: 100, opacity: 0 }}
@@ -62,7 +62,7 @@ export function CookieBanner() {
               </div>
             </div>
           </div>
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   );

--- a/apps/web/src/components/blog/filtered-articles.tsx
+++ b/apps/web/src/components/blog/filtered-articles.tsx
@@ -1,7 +1,7 @@
 import type { ArticleType } from '@xbrk/types';
 import { Input } from '@xbrk/ui/input';
 import { Label } from '@xbrk/ui/label';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { FileText, Search } from 'lucide-react';
 import { type ChangeEvent, useState } from 'react';
 import { containerVariants, itemVariants } from '@/lib/constants/framer-motion-variants';
@@ -47,18 +47,18 @@ export default function FilteredArticles({ articles }: Readonly<FilteredArticles
       </div>
 
       {filteredArticles.length ? (
-        <motion.div
+        <m.div
           animate="visible"
           className="grid gap-6 sm:grid-cols-2"
           initial="hidden"
           variants={containerVariants}
         >
           {filteredArticles.map((article) => (
-            <motion.div key={article.slug} variants={itemVariants}>
+            <m.div key={article.slug} variants={itemVariants}>
               <ArticleCard article={article} />
-            </motion.div>
+            </m.div>
           ))}
-        </motion.div>
+        </m.div>
       ) : (
         <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">

--- a/apps/web/src/components/bookmarks/bookmark-list.tsx
+++ b/apps/web/src/components/bookmarks/bookmark-list.tsx
@@ -1,5 +1,5 @@
 import { type Bookmark } from '@xbrk/types';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import BookmarkCard from '@/components/bookmarks/bookmark-card';
 import LoadMore from '@/components/bookmarks/load-more';
 import { PAGE_SIZE } from '@/lib/integrations/raindrop';
@@ -33,13 +33,13 @@ export default function BookmarkList({ id, initialBookmarks }: Readonly<Bookmark
 
   return (
     <div className="space-y-8">
-      <motion.div animate="visible" className="grid gap-4 sm:grid-cols-2" initial="hidden" variants={containerVariants}>
+      <m.div animate="visible" className="grid gap-4 sm:grid-cols-2" initial="hidden" variants={containerVariants}>
         {initialBookmarks.map((bookmark) => (
-          <motion.div key={bookmark._id} variants={itemVariants}>
+          <m.div key={bookmark._id} variants={itemVariants}>
             <BookmarkCard bookmark={bookmark} />
-          </motion.div>
+          </m.div>
         ))}
-      </motion.div>
+      </m.div>
 
       {isLoadMoreEnabled && <LoadMore id={id} />}
     </div>

--- a/apps/web/src/components/chatbot/content.tsx
+++ b/apps/web/src/components/chatbot/content.tsx
@@ -1,6 +1,6 @@
 import { createChatClientOptions } from '@tanstack/ai-client';
 import { fetchServerSentEvents, useChat } from '@tanstack/ai-react';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { useEffect, useRef } from 'react';
 import { useChatHistory } from '@/hooks/use-chat-history';
 import { ChatHeader } from './header';
@@ -47,7 +47,7 @@ export function ChatbotContent({
 
   return (
     <>
-      <motion.div
+      <m.div
         animate={{ opacity: 1 }}
         className="fixed inset-0 z-50 bg-black/30 backdrop-blur-sm lg:bg-transparent"
         exit={{ opacity: 0 }}
@@ -55,7 +55,7 @@ export function ChatbotContent({
         onClick={() => setIsOpen(false)}
       />
 
-      <motion.div
+      <m.div
         animate={{ opacity: 1, scale: 1, y: 0 }}
         className="fixed inset-4 z-50 lg:inset-auto lg:right-6 lg:bottom-24 lg:h-[550px] lg:w-[420px]"
         exit={{ opacity: 0, scale: 0.95, y: 10 }}
@@ -74,7 +74,7 @@ export function ChatbotContent({
             <ChatInput isLoading={isLoading} sendMessage={sendMessage} />
           </div>
         </div>
-      </motion.div>
+      </m.div>
     </>
   );
 }

--- a/apps/web/src/components/chatbot/index.tsx
+++ b/apps/web/src/components/chatbot/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@xbrk/ui/button';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, m } from 'framer-motion';
 import { MessageCircle } from 'lucide-react';
 import { lazy, Suspense, useCallback, useState } from 'react';
 
@@ -13,7 +13,7 @@ export function Chatbot() {
 
   return (
     <>
-      <motion.div
+      <m.div
         animate={{ scale: 1 }}
         className="fixed right-6 bottom-6 z-50"
         initial={{ scale: 0 }}
@@ -31,7 +31,7 @@ export function Chatbot() {
         >
           <MessageCircle className="h-16 w-16 text-primary-foreground" />
         </Button>
-      </motion.div>
+      </m.div>
 
       <AnimatePresence>
         {isOpen ? (

--- a/apps/web/src/components/github-stats/github-contributor.tsx
+++ b/apps/web/src/components/github-stats/github-contributor.tsx
@@ -1,6 +1,6 @@
 import { ClientOnly } from '@tanstack/react-router';
 import { useTheme } from '@xbrk/shared/theme-provider';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Calendar, GitBranch } from 'lucide-react';
 import { GitHubCalendar } from 'react-github-calendar';
 import GithubActivityGraph from '@/components/github-stats/github-activity-graph';
@@ -17,7 +17,7 @@ export default function GithubContributor() {
   }
 
   return (
-    <motion.div
+    <m.div
       animate={{ opacity: 1, y: 0 }}
       className="mt-16 space-y-8"
       initial={{ opacity: 0, y: 20 }}
@@ -62,6 +62,6 @@ export default function GithubContributor() {
 
       {/* Activity graph */}
       <GithubActivityGraph />
-    </motion.div>
+    </m.div>
   );
 }

--- a/apps/web/src/components/github-stats/index.tsx
+++ b/apps/web/src/components/github-stats/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { FaGithub } from 'react-icons/fa';
 import StatCard from '@/components/github-stats/card';
 import GithubContributor from '@/components/github-stats/github-contributor';
@@ -46,7 +46,7 @@ export default function Stats() {
   return (
     <div className="space-y-8">
       {/* Header */}
-      <motion.div
+      <m.div
         animate={{ opacity: 1, y: 0 }}
         className="flex items-center gap-3"
         initial={{ opacity: 0, y: 20 }}
@@ -56,10 +56,10 @@ export default function Stats() {
           <FaGithub className="h-5 w-5 text-primary" />
         </div>
         <h2 className="font-semibold text-xl">GitHub Overview</h2>
-      </motion.div>
+      </m.div>
 
       {/* Stat cards */}
-      <motion.div
+      <m.div
         animate={{ opacity: 1, y: 0 }}
         className="grid grid-cols-1 gap-4 sm:grid-cols-3"
         initial={{ opacity: 0, y: 20 }}
@@ -68,7 +68,7 @@ export default function Stats() {
         {statCards.map((card) => (
           <StatCard card={card} key={card.title} />
         ))}
-      </motion.div>
+      </m.div>
 
       <GithubContributor />
     </div>

--- a/apps/web/src/components/guestbook/messages.tsx
+++ b/apps/web/src/components/guestbook/messages.tsx
@@ -1,5 +1,5 @@
 import type { GuestbookType, UserType } from '@xbrk/types';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { MessageSquare } from 'lucide-react';
 import { containerVariants, itemVariants } from '@/lib/constants/framer-motion-variants';
 import Message from './message';
@@ -26,12 +26,12 @@ export default function Messages({ messages }: Readonly<MessageProps>) {
   }
 
   return (
-    <motion.div animate="visible" className="mt-8 space-y-2" initial="hidden" variants={containerVariants}>
+    <m.div animate="visible" className="mt-8 space-y-2" initial="hidden" variants={containerVariants}>
       {messages.map((message) => (
-        <motion.div key={message.id} variants={itemVariants}>
+        <m.div key={message.id} variants={itemVariants}>
           <Message message={message} />
-        </motion.div>
+        </m.div>
       ))}
-    </motion.div>
+    </m.div>
   );
 }

--- a/apps/web/src/components/home/connect-section.tsx
+++ b/apps/web/src/components/home/connect-section.tsx
@@ -1,6 +1,6 @@
 import { siteConfig, socialConfig } from '@xbrk/config';
 import Icon from '@xbrk/ui/icon';
-import { motion, useInView } from 'framer-motion';
+import { m, useInView } from 'framer-motion';
 import { Mail } from 'lucide-react';
 import { useRef } from 'react';
 import Link from '@/components/shared/link';
@@ -15,11 +15,11 @@ const ConnectSection = () => {
   const isInView = useInView(sectionRef, { once: true, margin: '-100px' });
 
   return (
-    <motion.section
+    <m.section
       animate={isInView ? 'visible' : 'hidden'}
       className="w-full"
       id="connect"
-      initial="hidden"
+      initial={false}
       ref={sectionRef}
       transition={{ duration: 0.5 }}
       variants={sectionVariants}
@@ -29,10 +29,10 @@ const ConnectSection = () => {
         <div className="pointer-events-none absolute top-0 right-0 h-64 w-64 rounded-full bg-gradient-to-br from-violet-500/10 to-pink-500/10 blur-3xl" />
         <div className="pointer-events-none absolute bottom-0 left-0 h-48 w-48 rounded-full bg-gradient-to-tr from-cyan-500/10 to-blue-500/10 blur-3xl" />
 
-        <motion.div
+        <m.div
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           className="relative flex flex-col items-center text-center"
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           transition={{ duration: 0.5, delay: 0.2 }}
         >
           <h2 className="font-bold text-2xl tracking-tight sm:text-3xl md:text-4xl">Say Hi</h2>
@@ -75,9 +75,9 @@ const ConnectSection = () => {
               guestbook
             </Link>
           </p>
-        </motion.div>
+        </m.div>
       </div>
-    </motion.section>
+    </m.section>
   );
 };
 

--- a/apps/web/src/components/home/featured-projects.tsx
+++ b/apps/web/src/components/home/featured-projects.tsx
@@ -1,7 +1,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
-import { motion, useInView } from 'framer-motion';
+import { m, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useRef } from 'react';
 import Link from '@/components/shared/link';
@@ -63,75 +63,73 @@ const FeaturedProjects = () => {
   const featuredProjects = featured.length > 0 ? featured : projects.slice(0, 4);
 
   return (
-    <motion.section
+    <m.section
       animate={isInView ? 'visible' : 'hidden'}
       className="w-full"
       id="featured-projects"
-      initial="hidden"
+      initial={false}
       ref={sectionRef}
       transition={{ duration: 0.5 }}
       variants={sectionVariants}
     >
       <div className="my-8 flex flex-col items-center px-1 py-4 text-center sm:mb-10">
-        <motion.span
+        <m.span
           animate={isInView ? { opacity: 1 } : { opacity: 0 }}
           className="mb-3 font-medium text-primary text-sm uppercase tracking-widest"
-          initial={{ opacity: 0 }}
+          initial={false}
           transition={{ delay: 0.1 }}
         >
           Side Projects
-        </motion.span>
-        <motion.h2
+        </m.span>
+        <m.h2
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           className="font-bold text-3xl tracking-tight sm:text-4xl"
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           transition={{ delay: 0.2 }}
         >
           Things I've Built
-        </motion.h2>
-        <motion.p
+        </m.h2>
+        <m.p
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           className="mt-3 max-w-2xl text-muted-foreground"
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           transition={{ delay: 0.3 }}
         >
           Fun stuff I build on weekends and evenings. Some useful, some just for learning.
-        </motion.p>
+        </m.p>
       </div>
 
       {featuredProjects.length > 0 ? (
         <>
-          <motion.div
-            animate="visible"
+          <m.div
+            animate={isInView ? 'visible' : 'hidden'}
             className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6"
-            initial="hidden"
+            initial={false}
             variants={containerVariantsFast}
-            viewport={{ once: true }}
-            whileInView="visible"
           >
             {featuredProjects.map((project) => (
-              <motion.div key={project.slug} variants={itemVariantsDown}>
+              <m.div key={project.slug} variants={itemVariantsDown}>
                 <ProjectCard project={project} />
-              </motion.div>
+              </m.div>
             ))}
-          </motion.div>
+          </m.div>
 
-          <motion.div
-            animate={{ opacity: 1, y: 0 }}
+          <m.div
+            animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
             className="mt-10 flex justify-center"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             transition={{ delay: 0.5 }}
           >
             <Link className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'group')} href="/projects">
               View all projects
               <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
             </Link>
-          </motion.div>
+          </m.div>
         </>
       ) : (
         <EmptyState message="The projects are probably off having a party somewhere without us!" />
       )}
-    </motion.section>
+    </m.section>
   );
 };
 

--- a/apps/web/src/components/home/personal-hero.tsx
+++ b/apps/web/src/components/home/personal-hero.tsx
@@ -3,7 +3,7 @@ import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
 import Icon from '@xbrk/ui/icon';
 import { LazyImage } from '@xbrk/ui/lazy-image';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { ChevronDownIcon } from 'lucide-react';
 import Link from '@/components/shared/link';
 
@@ -42,10 +42,10 @@ const PersonalHero = () => (
     {/* Main content - uses direct Tailwind flex classes instead of Container component */}
     <div className="flex min-h-[calc(100vh-80px)] flex-col items-center justify-center gap-8 py-8 sm:py-16 lg:flex-row lg:gap-16">
       {/* Left side - Content */}
-      <motion.div
+      <m.div
         animate={{ opacity: 1, x: 0 }}
-        className="flex max-w-2xl flex-col gap-6 text-center lg:w-1/2 lg:text-left"
-        initial={{ opacity: 0, x: -30 }}
+        className="flex max-w-2xl flex-col gap-6 text-center lg:w-1/2 lg:text-left animate-in fade-in slide-in-from-left-8 duration-700"
+        initial={false}
         transition={{ duration: 0.6, ease: 'easeOut' }}
       >
         {/* Greeting + Name */}
@@ -64,10 +64,10 @@ const PersonalHero = () => (
         </p>
 
         {/* CTAs - Call-to-action buttons for navigation */}
-        <motion.div
+        <m.div
           animate={{ opacity: 1, y: 0 }}
-          className="mt-2 flex flex-col items-center justify-center gap-4 sm:flex-row lg:justify-start"
-          initial={{ opacity: 0, y: 20 }}
+        className="mt-2 flex flex-col items-center justify-center gap-4 sm:flex-row lg:justify-start animate-in fade-in slide-in-from-bottom-4 duration-700 delay-300 fill-mode-both"
+        initial={false}
           transition={{ delay: 0.4 }}
         >
           <Link className={cn(buttonVariants({ size: 'lg', variant: 'shadow' }), 'group')} to="/#featured-projects">
@@ -77,13 +77,13 @@ const PersonalHero = () => (
           <Link className={buttonVariants({ size: 'lg', variant: 'outline' })} to="/about">
             More About Me
           </Link>
-        </motion.div>
+        </m.div>
 
         {/* Social links - Links to social media profiles */}
-        <motion.div
+        <m.div
           animate={{ opacity: 1 }}
-          className="flex justify-center gap-2 lg:justify-start"
-          initial={{ opacity: 0 }}
+        className="flex justify-center gap-2 lg:justify-start animate-in fade-in duration-700 delay-500 fill-mode-both"
+        initial={false}
           transition={{ delay: 0.6 }}
         >
           {socialConfig.map((social) => (
@@ -101,14 +101,14 @@ const PersonalHero = () => (
               <span className="sr-only">{social.name}</span>
             </a>
           ))}
-        </motion.div>
-      </motion.div>
+        </m.div>
+      </m.div>
 
       {/* Right side - Avatar with decorative effects */}
-      <motion.div
+      <m.div
         animate={{ opacity: 1, scale: 1 }}
-        className="relative hidden lg:block lg:w-2/5"
-        initial={{ opacity: 0, scale: 0.9 }}
+        className="relative hidden lg:block lg:w-2/5 animate-in fade-in zoom-in-90 duration-700 delay-200 fill-mode-both"
+        initial={false}
         transition={{ duration: 0.6, delay: 0.2 }}
       >
         {/* Glow effect - Optional decorative gradient glow behind avatar */}
@@ -127,7 +127,7 @@ const PersonalHero = () => (
             />
           </div>
         </div>
-      </motion.div>
+      </m.div>
     </div>
   </section>
 );

--- a/apps/web/src/components/home/recent-posts.tsx
+++ b/apps/web/src/components/home/recent-posts.tsx
@@ -1,7 +1,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
-import { motion, useInView } from 'framer-motion';
+import { m, useInView } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { useRef } from 'react';
 import Link from '@/components/shared/link';
@@ -44,75 +44,73 @@ const RecentPosts = () => {
   const recentArticles = articles.slice(0, 3);
 
   return (
-    <motion.section
+    <m.section
       animate={isInView ? 'visible' : 'hidden'}
       className="w-full"
       id="recent-posts"
-      initial="hidden"
+      initial={false}
       ref={sectionRef}
       transition={{ duration: 0.5 }}
       variants={sectionVariants}
     >
       <div className="mb-6 flex flex-col items-center px-1 py-4 text-center sm:mb-10">
-        <motion.span
+        <m.span
           animate={isInView ? { opacity: 1 } : { opacity: 0 }}
           className="mb-3 font-medium text-primary text-sm uppercase tracking-widest"
-          initial={{ opacity: 0 }}
+          initial={false}
           transition={{ delay: 0.1 }}
         >
           From the Blog
-        </motion.span>
-        <motion.h2
+        </m.span>
+        <m.h2
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           className="font-bold text-3xl tracking-tight sm:text-4xl"
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           transition={{ delay: 0.2 }}
         >
           Latest Writing
-        </motion.h2>
-        <motion.p
+        </m.h2>
+        <m.p
           animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
           className="mt-3 max-w-2xl text-muted-foreground"
-          initial={{ opacity: 0, y: 20 }}
+          initial={false}
           transition={{ delay: 0.3 }}
         >
           Thoughts on tech, side projects, and things I find interesting.
-        </motion.p>
+        </m.p>
       </div>
 
       {recentArticles.length > 0 ? (
         <>
-          <motion.div
-            animate="visible"
+          <m.div
+            animate={isInView ? 'visible' : 'hidden'}
             className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3"
-            initial="hidden"
+            initial={false}
             variants={containerVariantsFast}
-            viewport={{ once: true }}
-            whileInView="visible"
           >
             {recentArticles.map((article) => (
-              <motion.div key={article.slug} variants={itemVariantsDown}>
+              <m.div key={article.slug} variants={itemVariantsDown}>
                 <ArticleCard article={article} />
-              </motion.div>
+              </m.div>
             ))}
-          </motion.div>
+          </m.div>
 
-          <motion.div
-            animate={{ opacity: 1, y: 0 }}
+          <m.div
+            animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
             className="mt-10 flex justify-center"
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             transition={{ delay: 0.5 }}
           >
             <Link className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'group')} href="/blog">
               View all posts
               <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
             </Link>
-          </motion.div>
+          </m.div>
         </>
       ) : (
         <EmptyState message="The posts are playing hide and seek – we just can't find them!" />
       )}
-    </motion.section>
+    </m.section>
   );
 };
 

--- a/apps/web/src/components/layout/footer.tsx
+++ b/apps/web/src/components/layout/footer.tsx
@@ -1,7 +1,7 @@
 import { siteConfig, socialConfig } from '@xbrk/config';
 import { cn } from '@xbrk/ui';
 import Icon from '@xbrk/ui/icon';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import Link from '@/components/shared/link';
 import { FOOTER_LINKS } from '@/lib/constants/footer';
 
@@ -16,7 +16,7 @@ const Footer = () => (
     />
 
     <div className="container py-12 lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl">
-      <motion.div
+      <m.div
         animate={{ opacity: 1, y: 0 }}
         className="mb-8 grid grid-cols-2 gap-8 md:grid-cols-4"
         initial={{ opacity: 0, y: 20 }}
@@ -44,7 +44,7 @@ const Footer = () => (
             </div>
           ))}
         </nav>
-      </motion.div>
+      </m.div>
 
       {/* Horizontal divider */}
       <div aria-hidden="true" className="my-8 border-border/50 border-t" />

--- a/apps/web/src/components/projects/projects.tsx
+++ b/apps/web/src/components/projects/projects.tsx
@@ -1,5 +1,5 @@
 import type { ProjectType } from '@xbrk/types';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { slideInWithFadeOut } from '@/lib/constants/framer-motion-variants';
 import EmptyState from '../shared/empty-state';
 import ProjectCard from './project-card';
@@ -14,7 +14,7 @@ export default function Projects({ projects }: Readonly<ProjectsProps>) {
   }
 
   return (
-    <motion.div
+    <m.div
       animate="visible"
       className="grid grid-cols-1 gap-8 sm:grid-cols-2"
       initial="hidden"
@@ -23,6 +23,6 @@ export default function Projects({ projects }: Readonly<ProjectsProps>) {
       {projects.map((project) => (
         <ProjectCard key={project.slug} project={project} />
       ))}
-    </motion.div>
+    </m.div>
   );
 }

--- a/apps/web/src/components/providers/motion-provider.tsx
+++ b/apps/web/src/components/providers/motion-provider.tsx
@@ -1,0 +1,9 @@
+import { LazyMotion, domAnimation } from "framer-motion"
+
+export function MotionProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <LazyMotion features={domAnimation} strict>
+      {children}
+    </LazyMotion>
+  )
+}

--- a/apps/web/src/components/services/services.tsx
+++ b/apps/web/src/components/services/services.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { containerVariantsFast, itemVariantsDown } from '@/lib/constants/framer-motion-variants';
 import { queryKeys } from '@/lib/query-keys';
 import { $getAllPublicServices } from '@/lib/server';
@@ -15,34 +15,34 @@ export default function Services() {
   return (
     <section className="w-full">
       <div className="mb-6 flex flex-col items-center px-1 text-center sm:mb-10">
-        <motion.span
+        <m.span
           animate={{ opacity: 1 }}
           className="mb-3 font-medium text-primary text-sm uppercase tracking-widest"
           initial={{ opacity: 0 }}
           transition={{ delay: 0.1 }}
         >
           What I Offer
-        </motion.span>
-        <motion.h2
+        </m.span>
+        <m.h2
           animate={{ opacity: 1, y: 0 }}
           className="font-bold text-3xl tracking-tight sm:text-4xl"
           initial={{ opacity: 0, y: 20 }}
           transition={{ delay: 0.2 }}
         >
           Services That Drive Results
-        </motion.h2>
-        <motion.p
+        </m.h2>
+        <m.p
           animate={{ opacity: 1, y: 0 }}
           className="mt-3 max-w-2xl text-muted-foreground"
           initial={{ opacity: 0, y: 20 }}
           transition={{ delay: 0.3 }}
         >
           From concept to deployment, I provide end-to-end development services tailored to your business needs.
-        </motion.p>
+        </m.p>
       </div>
 
       {services.length > 0 ? (
-        <motion.div
+        <m.div
           animate="visible"
           className="flex flex-col gap-4 sm:gap-8"
           initial="hidden"
@@ -51,11 +51,11 @@ export default function Services() {
           whileInView="visible"
         >
           {services.map((service) => (
-            <motion.div key={service.slug} variants={itemVariantsDown}>
+            <m.div key={service.slug} variants={itemVariantsDown}>
               <ServiceCard service={service} />
-            </motion.div>
+            </m.div>
           ))}
-        </motion.div>
+        </m.div>
       ) : (
         <EmptyState message="Services are currently being crafted with care – check back soon!" />
       )}

--- a/apps/web/src/components/shared/animated-div.tsx
+++ b/apps/web/src/components/shared/animated-div.tsx
@@ -1,4 +1,4 @@
-import { motion, type Variants } from 'framer-motion';
+import { m, type Variants } from 'framer-motion';
 import type { HTMLAttributes, ReactNode } from 'react';
 
 interface AnimatedDivProps extends HTMLAttributes<HTMLDivElement> {
@@ -9,7 +9,7 @@ interface AnimatedDivProps extends HTMLAttributes<HTMLDivElement> {
 
 export default function AnimatedDiv({ variants, className, children, loop }: AnimatedDivProps) {
   return (
-    <motion.div
+    <m.div
       className={className}
       initial="hidden"
       transition={{ staggerChildren: 0.5 }}
@@ -18,6 +18,6 @@ export default function AnimatedDiv({ variants, className, children, loop }: Ani
       whileInView="visible"
     >
       {children}
-    </motion.div>
+    </m.div>
   );
 }

--- a/apps/web/src/components/shared/empty-state.tsx
+++ b/apps/web/src/components/shared/empty-state.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Frown } from 'lucide-react';
 
 interface EmptyStateProps {
@@ -12,28 +12,28 @@ interface EmptyStateProps {
  */
 const EmptyState = ({ message }: EmptyStateProps) => {
   return (
-    <motion.div
+    <m.div
       animate={{ opacity: 1, y: 0, scale: 1 }}
       className="my-4 flex flex-col items-center justify-center space-y-3 py-8"
       initial={{ opacity: 0, y: 20, scale: 0.95 }}
       transition={{ duration: 0.5, ease: 'easeOut' }}
     >
-      <motion.div
+      <m.div
         animate={{ opacity: 1, scale: 1 }}
         initial={{ opacity: 0, scale: 0.8 }}
         transition={{ duration: 0.4, delay: 0.1, ease: 'backOut' }}
       >
         <Frown className="size-12 text-muted-foreground" />
-      </motion.div>
-      <motion.p
+      </m.div>
+      <m.p
         animate={{ opacity: 1, y: 0 }}
         className="text-center text-muted-foreground"
         initial={{ opacity: 0, y: 10 }}
         transition={{ duration: 0.4, delay: 0.2 }}
       >
         {message}
-      </motion.p>
-    </motion.div>
+      </m.p>
+    </m.div>
   );
 };
 

--- a/apps/web/src/components/shared/page-heading.tsx
+++ b/apps/web/src/components/shared/page-heading.tsx
@@ -4,8 +4,8 @@ import { m } from 'framer-motion';
 import type { HTMLAttributes, ReactNode } from 'react';
 import { useMemo } from 'react';
 
-const MotionDiv = motion.create('div');
-const MotionSlot = motion.create(Slot);
+const MotionDiv = m.create('div');
+const MotionSlot = m.create(Slot);
 
 interface PageHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
   asChild?: boolean;

--- a/apps/web/src/components/shared/page-heading.tsx
+++ b/apps/web/src/components/shared/page-heading.tsx
@@ -1,6 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
 import { cn } from '@xbrk/ui';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import type { HTMLAttributes, ReactNode } from 'react';
 import { useMemo } from 'react';
 
@@ -57,21 +57,21 @@ const PageHeading = ({
 
         <div className={cn('relative space-y-3', { 'text-center': centered })}>
           {hasMotion ? (
-            <motion.h1
+            <m.h1
               animate={animation.show}
               className="font-bold text-4xl tracking-tight md:text-5xl lg:text-6xl"
               initial={animation.hide}
               transition={{ delay: 0.1 }}
             >
               {title}
-            </motion.h1>
+            </m.h1>
           ) : (
             <h1 className="font-bold text-3xl tracking-tight md:text-4xl lg:text-5xl">{title}</h1>
           )}
 
           {description &&
             (hasMotion ? (
-              <motion.p
+              <m.p
                 animate={animation.show}
                 className={cn(
                   'text-muted-foreground leading-relaxed md:text-lg',
@@ -81,7 +81,7 @@ const PageHeading = ({
                 transition={{ delay: 0.2 }}
               >
                 {description}
-              </motion.p>
+              </m.p>
             ) : (
               <p
                 className={cn(
@@ -95,14 +95,14 @@ const PageHeading = ({
 
           {children &&
             (hasMotion ? (
-              <motion.div
+              <m.div
                 animate={animation.show}
                 className="pointer-events-auto pt-3"
                 initial={animation.hide}
                 transition={{ delay: 0.3 }}
               >
                 {children}
-              </motion.div>
+              </m.div>
             ) : (
               <div className="pointer-events-auto pt-3">{children}</div>
             ))}

--- a/apps/web/src/components/skeletons/article-card-skeleton.tsx
+++ b/apps/web/src/components/skeletons/article-card-skeleton.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@xbrk/ui';
+
+export function ArticleCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex h-full flex-col overflow-hidden rounded-xl border bg-card sm:rounded-2xl", className)}>
+      <div className="relative aspect-[16/9] w-full animate-pulse bg-muted" />
+      <div className="flex flex-1 flex-col gap-3 p-4 sm:p-5">
+        <div className="flex gap-2">
+          <div className="h-5 w-20 animate-pulse rounded-md bg-muted" />
+          <div className="h-5 w-24 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="h-6 w-full animate-pulse rounded-md bg-muted" />
+        <div className="space-y-2">
+          <div className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-4/5 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="mt-auto pt-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+            <div className="h-4 w-20 animate-pulse rounded-md bg-muted" />
+          </div>
+          <div className="h-4 w-16 animate-pulse rounded-md bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/skeletons/project-card-skeleton.tsx
+++ b/apps/web/src/components/skeletons/project-card-skeleton.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@xbrk/ui';
+
+export function ProjectCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex h-full flex-col overflow-hidden rounded-xl border bg-card sm:rounded-2xl", className)}>
+      <div className="relative aspect-[16/10] w-full animate-pulse bg-muted" />
+      <div className="flex flex-1 flex-col gap-3 p-4 sm:p-5">
+        <div className="h-6 w-3/4 animate-pulse rounded-md bg-muted" />
+        <div className="space-y-2">
+          <div className="h-4 w-full animate-pulse rounded-md bg-muted" />
+          <div className="h-4 w-5/6 animate-pulse rounded-md bg-muted" />
+        </div>
+        <div className="mt-auto pt-3 flex gap-2">
+          <div className="h-6 w-16 animate-pulse rounded-full bg-muted" />
+          <div className="h-6 w-16 animate-pulse rounded-full bg-muted" />
+          <div className="h-6 w-16 animate-pulse rounded-full bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/snippets/index.tsx
+++ b/apps/web/src/components/snippets/index.tsx
@@ -1,7 +1,7 @@
 import type { SnippetType } from '@xbrk/types';
 import { Badge } from '@xbrk/ui/badge';
 import { formatDate } from '@xbrk/utils';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { ArrowUpRight, Calendar, Code2 } from 'lucide-react';
 import Link from '@/components/shared/link';
 import { containerVariants, itemVariants } from '@/lib/constants/framer-motion-variants';
@@ -17,9 +17,9 @@ export default function Snippets({ snippets }: Readonly<SnippetsProps>) {
   }
 
   return (
-    <motion.div animate="visible" className="grid gap-4 sm:grid-cols-2" initial="hidden" variants={containerVariants}>
+    <m.div animate="visible" className="grid gap-4 sm:grid-cols-2" initial="hidden" variants={containerVariants}>
       {snippets.map((snippet) => (
-        <motion.div key={snippet.slug} variants={itemVariants}>
+        <m.div key={snippet.slug} variants={itemVariants}>
           <Link
             className="group relative flex h-full flex-col overflow-hidden rounded-2xl border bg-card p-5 transition-all duration-300 hover:border-foreground/20 hover:shadow-xl"
             params={{
@@ -62,8 +62,8 @@ export default function Snippets({ snippets }: Readonly<SnippetsProps>) {
               </div>
             </div>
           </Link>
-        </motion.div>
+        </m.div>
       ))}
-    </motion.div>
+    </m.div>
   );
 }

--- a/apps/web/src/components/uses/uses.tsx
+++ b/apps/web/src/components/uses/uses.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Layers } from 'lucide-react';
 import type { SimpleIcon } from 'simple-icons';
 import Link from '@/components/shared/link';
@@ -40,7 +40,7 @@ export default function Uses() {
         <h2 className="font-semibold text-xl">Software & Applications</h2>
       </div>
 
-      <motion.div
+      <m.div
         animate="visible"
         className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8"
         initial="hidden"
@@ -50,7 +50,7 @@ export default function Uses() {
           const Icon = createIconComponent(item.icon);
 
           return (
-            <motion.div key={item.name} variants={itemVariants}>
+            <m.div key={item.name} variants={itemVariants}>
               <Link
                 className="group flex flex-col items-center justify-center gap-3 rounded-2xl border bg-card p-4 transition-all duration-300 hover:border-foreground/20 hover:shadow-lg active:scale-95"
                 rel="noopener noreferrer"
@@ -62,10 +62,10 @@ export default function Uses() {
                 </div>
                 <p className="line-clamp-1 text-center font-medium text-xs">{item.name}</p>
               </Link>
-            </motion.div>
+            </m.div>
           );
         })}
-      </motion.div>
+      </m.div>
     </div>
   );
 }

--- a/apps/web/src/routes/(public)/about/index.tsx
+++ b/apps/web/src/routes/(public)/about/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { siteConfig } from '@xbrk/config';
 import { Button } from '@xbrk/ui/button';
 import { LazyImage } from '@xbrk/ui/lazy-image';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { DownloadIcon, FileTextIcon } from 'lucide-react';
 import Biography from '@/components/about/biography';
 import CareerJourney from '@/components/about/career-journey';
@@ -50,7 +50,7 @@ function RouteComponent() {
 
       <div className="items-start space-y-2 xl:grid xl:grid-cols-4 xl:gap-x-6 xl:space-y-0">
         {/* Sidebar - Avatar, Name, Buttons with motion animation */}
-        <motion.div
+        <m.div
           animate={{ opacity: 1, x: 0 }}
           className="group flex flex-col items-center xl:sticky xl:top-24"
           initial={{ opacity: 0, x: -30 }}
@@ -85,31 +85,31 @@ function RouteComponent() {
               </Link>
             </Button>
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Main Content - Each section animates individually */}
         <div className="prose prose-neutral dark:prose-invert max-w-none xl:col-span-3">
           {/* Biography section */}
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             initial={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.5, ease: 'easeOut', delay: 0.2 }}
           >
             <Biography />
-          </motion.div>
+          </m.div>
 
           {/* Tech Stack section */}
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             initial={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.5, ease: 'easeOut', delay: 0.4 }}
           >
             <h2 className="font-cal text-3xl">Tech Stack</h2>
             <TechStacks />
-          </motion.div>
+          </m.div>
 
           {/* Career Journey section */}
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             initial={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.5, ease: 'easeOut', delay: 0.6 }}
@@ -117,7 +117,7 @@ function RouteComponent() {
             <h2 className="font-cal text-3xl">Career Journey</h2>
             <p className="m-0! text-muted-foreground">A timeline of my professional experience and education.</p>
             <CareerJourney header={true} />
-          </motion.div>
+          </m.div>
         </div>
       </div>
     </>

--- a/apps/web/src/routes/(public)/blog/$articleId.tsx
+++ b/apps/web/src/routes/(public)/blog/$articleId.tsx
@@ -6,7 +6,7 @@ import { LazyImage } from '@xbrk/ui/lazy-image';
 import { NotFound } from '@xbrk/ui/not-found';
 import { Spinner } from '@xbrk/ui/spinner';
 import { calculateReadingTime, formatDate } from '@xbrk/utils';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Calendar, Clock, Eye, Heart, MessageCircle, Tag } from 'lucide-react';
 import { Suspense, useEffect, useRef } from 'react';
 import SignInModal from '@/components/auth/sign-in-modal';
@@ -144,12 +144,12 @@ function RouteComponent() {
     <>
       <article className="relative lg:gap-10 xl:grid xl:max-w-6xl xl:grid-cols-[1fr_280px] 2xl:max-w-7xl">
         <div className="w-full min-w-0">
-          <motion.div animate={{ opacity: 1, y: 0 }} initial={{ opacity: 0, y: 20 }} transition={{ duration: 0.5 }}>
+          <m.div animate={{ opacity: 1, y: 0 }} initial={{ opacity: 0, y: 20 }} transition={{ duration: 0.5 }}>
             <BreadcrumbNavigation pageTitle={article.title} />
-          </motion.div>
+          </m.div>
 
           {/* Hero Section */}
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             className="relative"
             initial={{ opacity: 0, y: 30 }}
@@ -205,19 +205,19 @@ function RouteComponent() {
             </div>
 
             {/* Author section with enhanced styling */}
-            <motion.div
+            <m.div
               animate={{ opacity: 1, y: 0 }}
               className="mt-6"
               initial={{ opacity: 0, y: 20 }}
               transition={{ duration: 0.5, delay: 0.2 }}
             >
               <ArticleAuthor article={article} />
-            </motion.div>
-          </motion.div>
+            </m.div>
+          </m.div>
 
           {/* Featured image with glow effect */}
           {article.imageUrl && (
-            <motion.div
+            <m.div
               animate={{ opacity: 1, scale: 1 }}
               className="relative my-8 sm:my-10"
               initial={{ opacity: 0, scale: 0.98 }}
@@ -239,11 +239,11 @@ function RouteComponent() {
                   width={832}
                 />
               </div>
-            </motion.div>
+            </m.div>
           )}
 
           {/* Article content */}
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             initial={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.5, delay: 0.4 }}
@@ -253,10 +253,10 @@ function RouteComponent() {
                 <Markdown source={article.content ?? ''} />
               </article>
             </Suspense>
-          </motion.div>
+          </m.div>
 
           {/* Tags and share section */}
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             className="mt-12 border-border/50 border-t pt-8"
             initial={{ opacity: 0, y: 20 }}
@@ -281,22 +281,22 @@ function RouteComponent() {
                 url={`${siteConfig.url}/blog/${articleId}`}
               />
             </div>
-          </motion.div>
+          </m.div>
 
           {/* Comments section */}
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             className="mt-12"
             initial={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.5, delay: 0.6 }}
           >
             <ArticleComment articleId={article.id} articleSlug={article.slug} />
-          </motion.div>
+          </m.div>
         </div>
 
         {/* Table of contents - enhanced sticky sidebar */}
         {article.toc && (
-          <motion.div
+          <m.div
             animate={{ opacity: 1, x: 0 }}
             className="hidden text-sm xl:block"
             initial={{ opacity: 0, x: 20 }}
@@ -305,7 +305,7 @@ function RouteComponent() {
             <div className="sticky top-20 -mt-10 pt-10">
               <TableOfContents toc={article.toc} />
             </div>
-          </motion.div>
+          </m.div>
         )}
       </article>
       <SignInModal />

--- a/apps/web/src/routes/(public)/bookmarks/index.tsx
+++ b/apps/web/src/routes/(public)/bookmarks/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { siteConfig } from '@xbrk/config';
 import type { Collection } from '@xbrk/types';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { ArrowRight, Bookmark, FolderOpen } from 'lucide-react';
 import EmptyState from '@/components/shared/empty-state';
 import PageHeading from '@/components/shared/page-heading';
@@ -59,14 +59,14 @@ function RouteComponent() {
       {collections.length === 0 ? (
         <EmptyState message="No bookmarks found yet. We are discovering favorite discoveries!" />
       ) : (
-        <motion.div
+        <m.div
           animate="visible"
           className="grid gap-4 sm:grid-cols-2"
           initial="hidden"
           variants={containerVariants}
         >
           {collections.map((collection: Collection) => (
-            <motion.div key={collection._id} variants={itemVariants}>
+            <m.div key={collection._id} variants={itemVariants}>
               <Link
                 className="group relative flex h-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-border/50 bg-card p-5 transition-all duration-300 hover:border-border hover:shadow-lg hover:shadow-primary/5"
                 params={{
@@ -100,9 +100,9 @@ function RouteComponent() {
                   </span>
                 </div>
               </Link>
-            </motion.div>
+            </m.div>
           ))}
-        </motion.div>
+        </m.div>
       )}
     </>
   );

--- a/apps/web/src/routes/(public)/changelog/index.tsx
+++ b/apps/web/src/routes/(public)/changelog/index.tsx
@@ -3,7 +3,7 @@ import { siteConfig } from '@xbrk/config';
 import { Markdown } from '@xbrk/md';
 import type { TOC } from '@xbrk/types';
 import { Skeleton } from '@xbrk/ui/skeleton';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Suspense } from 'react';
 import TableOfContents from '@/components/blog/toc';
 import PageHeading from '@/components/shared/page-heading';
@@ -66,7 +66,7 @@ function RouteComponent() {
           </div>
         </div>
         {toc.length > 0 && (
-          <motion.div
+          <m.div
             animate={{ opacity: 1, x: 0 }}
             className="hidden text-sm xl:block"
             initial={{ opacity: 0, x: 20 }}
@@ -75,7 +75,7 @@ function RouteComponent() {
             <div className="sticky top-20 -mt-10 pt-10">
               <TableOfContents toc={toc} />
             </div>
-          </motion.div>
+          </m.div>
         )}
       </div>
     </>

--- a/apps/web/src/routes/(public)/index.tsx
+++ b/apps/web/src/routes/(public)/index.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { siteConfig } from '@xbrk/config';
-import { Spinner } from '@xbrk/ui/spinner';
 import { Suspense } from 'react';
 import ConnectSection from '@/components/home/connect-section';
 import FeaturedProjects from '@/components/home/featured-projects';
 import PersonalHero from '@/components/home/personal-hero';
 import RecentPosts from '@/components/home/recent-posts';
 import SectionDivider from '@/components/shared/section-divider';
+import { ArticleCardSkeleton } from '@/components/skeletons/article-card-skeleton';
+import { ProjectCardSkeleton } from '@/components/skeletons/project-card-skeleton';
 import { queryKeys } from '@/lib/query-keys';
 import { seo } from '@/lib/seo';
 import { $getAllPublicArticles, $getAllPublicProjects } from '@/lib/server';
@@ -57,11 +58,37 @@ function Home() {
       <PersonalHero />
 
       <div className="flex flex-col items-center gap-8">
-        <Suspense fallback={<Spinner />}>
+        <Suspense fallback={
+          <div className="w-full">
+            <div className="my-8 flex flex-col items-center px-1 py-4 text-center sm:mb-10">
+              <div className="mb-3 h-5 w-24 animate-pulse rounded-md bg-muted" />
+              <div className="h-10 w-64 animate-pulse rounded-md bg-muted" />
+              <div className="mt-3 h-6 w-96 max-w-full animate-pulse rounded-md bg-muted" />
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+              {[1, 2, 3, 4].map((i) => (
+                <ProjectCardSkeleton key={i} />
+              ))}
+            </div>
+          </div>
+        }>
           <FeaturedProjects />
         </Suspense>
         <SectionDivider />
-        <Suspense fallback={<Spinner />}>
+        <Suspense fallback={
+          <div className="w-full">
+            <div className="mb-6 flex flex-col items-center px-1 py-4 text-center sm:mb-10">
+              <div className="mb-3 h-5 w-32 animate-pulse rounded-md bg-muted" />
+              <div className="h-10 w-48 animate-pulse rounded-md bg-muted" />
+              <div className="mt-3 h-6 w-80 max-w-full animate-pulse rounded-md bg-muted" />
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
+              {[1, 2, 3].map((i) => (
+                <ArticleCardSkeleton key={i} />
+              ))}
+            </div>
+          </div>
+        }>
           <RecentPosts />
         </Suspense>
         <SectionDivider />

--- a/apps/web/src/routes/(public)/projects/$projectId.tsx
+++ b/apps/web/src/routes/(public)/projects/$projectId.tsx
@@ -9,7 +9,7 @@ import { NotFound } from '@xbrk/ui/not-found';
 import { Spinner } from '@xbrk/ui/spinner';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@xbrk/ui/tooltip';
 import ZoomImage from '@xbrk/ui/zoom-image';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Code2, ExternalLink, Sparkles } from 'lucide-react';
 import { Suspense } from 'react';
 import { siGithub } from 'simple-icons';
@@ -109,12 +109,12 @@ function RouteComponent() {
     <article className="relative lg:gap-10 xl:grid xl:max-w-6xl xl:grid-cols-[1fr_280px] 2xl:max-w-7xl">
       <div className="w-full min-w-0">
         {/* Breadcrumb */}
-        <motion.div animate={{ opacity: 1, y: 0 }} initial={{ opacity: 0, y: 20 }} transition={{ duration: 0.5 }}>
+        <m.div animate={{ opacity: 1, y: 0 }} initial={{ opacity: 0, y: 20 }} transition={{ duration: 0.5 }}>
           <BreadcrumbNavigation pageTitle={title} section={{ label: 'Projects', href: '/projects' }} />
-        </motion.div>
+        </m.div>
 
         {/* Hero Section */}
-        <motion.div
+        <m.div
           animate={{ opacity: 1, y: 0 }}
           className="relative"
           initial={{ opacity: 0, y: 30 }}
@@ -152,7 +152,7 @@ function RouteComponent() {
           <div className="mt-8 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
             {/* Tech stack */}
             {stacks && stacks.length > 0 && (
-              <motion.div
+              <m.div
                 animate={{ opacity: 1, y: 0 }}
                 className="flex flex-wrap items-center gap-3"
                 initial={{ opacity: 0, y: 20 }}
@@ -178,11 +178,11 @@ function RouteComponent() {
                     </TooltipProvider>
                   ))}
                 </div>
-              </motion.div>
+              </m.div>
             )}
 
             {/* Project links */}
-            <motion.div
+            <m.div
               animate={{ opacity: 1, y: 0 }}
               className="flex items-center gap-3"
               initial={{ opacity: 0, y: 20 }}
@@ -192,12 +192,12 @@ function RouteComponent() {
                 <ProjectLink icon={<Icon className="h-4 w-4" icon={siGithub} />} title="Source Code" url={githubUrl} />
               )}
               {demoUrl && <ProjectLink icon={<ExternalLink className="h-4 w-4" />} title="Live Demo" url={demoUrl} />}
-            </motion.div>
+            </m.div>
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Featured image with glow effect */}
-        <motion.div
+        <m.div
           animate={{ opacity: 1, scale: 1 }}
           className="relative my-10"
           initial={{ opacity: 0, scale: 0.98 }}
@@ -209,11 +209,11 @@ function RouteComponent() {
           <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-linear-to-br from-white/5 to-white/2 p-1.5 shadow-2xl">
             <ZoomImage alt={title} className="w-full rounded-xl" height={630} src={thumbnailUrl} width={1200} />
           </div>
-        </motion.div>
+        </m.div>
 
         {/* Project content */}
         {content && (
-          <motion.div
+          <m.div
             animate={{ opacity: 1, y: 0 }}
             className="mt-12"
             initial={{ opacity: 0, y: 20 }}
@@ -224,13 +224,13 @@ function RouteComponent() {
                 <Markdown source={content} />
               </div>
             </Suspense>
-          </motion.div>
+          </m.div>
         )}
       </div>
 
       {/* Table of contents - sticky sidebar */}
       {toc && toc.length > 0 && (
-        <motion.div
+        <m.div
           animate={{ opacity: 1, x: 0 }}
           className="hidden text-sm xl:block"
           initial={{ opacity: 0, x: 20 }}
@@ -239,7 +239,7 @@ function RouteComponent() {
           <div className="sticky top-20 -mt-10 pt-10">
             <TableOfContents toc={toc} />
           </div>
-        </motion.div>
+        </m.div>
       )}
     </article>
   );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { CookieBanner } from '@/components/analytics/cookie-banner';
 import { RouteProgress } from '@/components/shared/route-progress';
 import { type AuthQueryResult, authQueryOptions } from '@/lib/auth/queries';
 import { env } from '@/lib/env/client';
+import { MotionProvider } from '@/components/providers/motion-provider';
 import printCss from '@/print.css?url';
 import appCss from '@/style.css?url';
 
@@ -169,19 +170,21 @@ function ShellComponent({ children }: { children: React.ReactNode }) {
 
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">
         <PostHogProvider client={posthog}>
-          <RouteProgress />
+          <MotionProvider>
+            <RouteProgress />
 
-          {children}
+            {children}
 
-          <Toaster resolvedTheme={resolvedTheme} />
+            <Toaster resolvedTheme={resolvedTheme} />
 
-          {import.meta.env.DEV && <DevtoolsComponent />}
+            {import.meta.env.DEV && <DevtoolsComponent />}
 
-          <ClientOnly>
-            <CookieBanner />
-          </ClientOnly>
+            <ClientOnly>
+              <CookieBanner />
+            </ClientOnly>
 
-          <Scripts />
+            <Scripts />
+          </MotionProvider>
         </PostHogProvider>
       </body>
     </html>


### PR DESCRIPTION
This PR resolves a performance issue where the portfolio website showed a blank white screen on cold load due to Framer Motion's initial animation states interacting with SSR, which caused the HTML to be hidden (`opacity: 0`) until JS hydration completed.

**Changes made:**
- Wrapped the root component in `<LazyMotion features={domAnimation} strict>` and replaced all instances of `motion` with `m`. This defers the loading of Framer Motion's heavy logic, drastically reducing the initial JS bundle size and main thread blocking.
- Set `initial={false}` on the hero section (`PersonalHero`) and delegated the entrance animation to CSS (using `tailwindcss-animate` classes) to ensure content is immediately visible.
- Replaced generic spinners in the `Suspense` boundaries for the "Featured Projects" and "Recent Posts" sections with tailored `ProjectCardSkeleton` and `ArticleCardSkeleton` loaders to improve perceived loading performance and reduce layout shifts.

---
*PR created automatically by Jules for task [13860332841416057058](https://jules.google.com/task/13860332841416057058) started by @RLukas2*