### PR TITLE
Redesign dashboard to modern SaaS layout

### DIFF
--- a/apps/dashboard/src/components/blog/form.tsx
+++ b/apps/dashboard/src/components/blog/form.tsx
@@ -42,7 +42,7 @@ export const ArticleForm = withForm({
   },
   render({ form, article }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>
@@ -60,12 +60,11 @@ export const ArticleForm = withForm({
                 name="title"
               >
                 {(field) => (
-                  <div className="space-y-2">
+                  <field.FormItem>
                     <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                        Title
-                        <span className="ml-1 text-destructive">*</span>
-                      </span>
+                      <field.FormLabel>
+                        Title <span className="text-destructive">*</span>
+                      </field.FormLabel>
                       <AIAssistDialog
                         buttonSize="sm"
                         buttonVariant="ghost"
@@ -82,7 +81,7 @@ export const ArticleForm = withForm({
                       />
                     </div>
                     <FormInput field={field} label="" placeholder="Article Title" required />
-                  </div>
+                  </field.FormItem>
                 )}
               </form.AppField>
 
@@ -94,11 +93,9 @@ export const ArticleForm = withForm({
 
               <form.AppField name="description">
                 {(field) => (
-                  <div className="space-y-2">
+                  <field.FormItem>
                     <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                        Description
-                      </span>
+                      <field.FormLabel>Description</field.FormLabel>
                       <AIAssistDialog
                         buttonSize="sm"
                         buttonVariant="ghost"
@@ -115,12 +112,14 @@ export const ArticleForm = withForm({
                       />
                     </div>
                     <FormTextarea field={field} label="" placeholder="A brief description of your article" />
-                  </div>
+                  </field.FormItem>
                 )}
               </form.AppField>
             </CardContent>
           </Card>
+        </div>
 
+        <div className="flex flex-col gap-6 lg:col-span-3">
           <Card>
             <CardHeader>
               <CardTitle>Content</CardTitle>
@@ -129,11 +128,9 @@ export const ArticleForm = withForm({
             <CardContent>
               <form.AppField name="content">
                 {(field) => (
-                  <div className="space-y-2">
+                  <field.FormItem>
                     <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                        Content
-                      </span>
+                      <field.FormLabel>Content</field.FormLabel>
                       <div className="flex gap-2">
                         <AIAssistDialog
                           buttonSize="sm"
@@ -172,7 +169,7 @@ export const ArticleForm = withForm({
 ## Overview
 A brief overview of your article."
                     />
-                  </div>
+                  </field.FormItem>
                 )}
               </form.AppField>
             </CardContent>

--- a/apps/dashboard/src/components/blog/form.tsx
+++ b/apps/dashboard/src/components/blog/form.tsx
@@ -42,7 +42,7 @@ export const ArticleForm = withForm({
   },
   render({ form, article }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
+      <div className="grid gap-6 lg:grid-flow-dense lg:grid-cols-3 lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>

--- a/apps/dashboard/src/components/blog/form.tsx
+++ b/apps/dashboard/src/components/blog/form.tsx
@@ -1,6 +1,7 @@
 import { formOptions, type ValidationErrorMap } from '@tanstack/react-form';
 import { STACKS } from '@xbrk/shared/stack';
 import type { ArticleType } from '@xbrk/types';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@xbrk/ui/card';
 import { withForm } from '@xbrk/ui/form';
 import Icon from '@xbrk/ui/icon';
 import { generateSlug } from '@xbrk/utils';
@@ -41,167 +42,208 @@ export const ArticleForm = withForm({
   },
   render({ form, article }) {
     return (
-      <>
-        <form.AppField
-          listeners={{
-            onChange: ({ value }) => {
-              const slug = generateSlug(value);
-              form.setFieldValue('slug', slug);
-            },
-          }}
-          name="title"
-        >
-          {(field) => (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                  Title
-                  <span className="ml-1 text-destructive">*</span>
-                </span>
-                <AIAssistDialog
-                  buttonSize="sm"
-                  buttonVariant="ghost"
-                  context={{
-                    topic: form.getFieldValue('description') || '',
-                    currentContent: form.getFieldValue('content') || '',
-                  }}
-                  description="Get AI-generated title suggestions for your blog post"
-                  label="AI Suggest"
-                  onApply={(content) => {
-                    field.handleChange(content);
-                  }}
-                  type="title"
-                />
-              </div>
-              <FormInput field={field} label="" placeholder="Article Title" required />
-            </div>
-          )}
-        </form.AppField>
+      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>General Information</CardTitle>
+              <CardDescription>The core details of your blog article.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField
+                listeners={{
+                  onChange: ({ value }) => {
+                    const slug = generateSlug(value);
+                    form.setFieldValue('slug', slug);
+                  },
+                }}
+                name="title"
+              >
+                {(field) => (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                        Title
+                        <span className="ml-1 text-destructive">*</span>
+                      </span>
+                      <AIAssistDialog
+                        buttonSize="sm"
+                        buttonVariant="ghost"
+                        context={{
+                          topic: form.getFieldValue('description') || '',
+                          currentContent: form.getFieldValue('content') || '',
+                        }}
+                        description="Get AI-generated title suggestions for your blog post"
+                        label="AI Suggest"
+                        onApply={(content) => {
+                          field.handleChange(content);
+                        }}
+                        type="title"
+                      />
+                    </div>
+                    <FormInput field={field} label="" placeholder="Article Title" required />
+                  </div>
+                )}
+              </form.AppField>
 
-        <form.AppField name="slug">
-          {(field) => <FormSlug field={field} label="Slug" placeholder="article-title" urlPath="/blog/your-slug" />}
-        </form.AppField>
+              <form.AppField name="slug">
+                {(field) => (
+                  <FormSlug field={field} label="Slug" placeholder="article-title" urlPath="/blog/your-slug" />
+                )}
+              </form.AppField>
 
-        <form.AppField name="description">
-          {(field) => (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                  Description
-                </span>
-                <AIAssistDialog
-                  buttonSize="sm"
-                  buttonVariant="ghost"
-                  context={{
-                    title: form.getFieldValue('title') || '',
-                    currentContent: form.getFieldValue('content') || '',
-                  }}
-                  description="Generate a compelling description for your blog post"
-                  label="AI Suggest"
-                  onApply={(content) => {
-                    field.handleChange(content.trim());
-                  }}
-                  type="description"
-                />
-              </div>
-              <FormTextarea field={field} label="" placeholder="A brief description of your article" />
-            </div>
-          )}
-        </form.AppField>
+              <form.AppField name="description">
+                {(field) => (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                        Description
+                      </span>
+                      <AIAssistDialog
+                        buttonSize="sm"
+                        buttonVariant="ghost"
+                        context={{
+                          title: form.getFieldValue('title') || '',
+                          currentContent: form.getFieldValue('content') || '',
+                        }}
+                        description="Generate a compelling description for your blog post"
+                        label="AI Suggest"
+                        onApply={(content) => {
+                          field.handleChange(content.trim());
+                        }}
+                        type="description"
+                      />
+                    </div>
+                    <FormTextarea field={field} label="" placeholder="A brief description of your article" />
+                  </div>
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <form.AppField name="content">
-          {(field) => (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                  Content
-                </span>
-                <div className="flex gap-2">
-                  <AIAssistDialog
-                    buttonSize="sm"
-                    buttonVariant="ghost"
-                    context={{
-                      title: form.getFieldValue('title') || '',
-                      description: form.getFieldValue('description') || '',
-                    }}
-                    description="Create a detailed outline for your blog post"
-                    label="Create Outline"
-                    onApply={(content) => {
-                      field.handleChange(content.trim());
-                    }}
-                    type="outline"
-                  />
-                  <AIAssistDialog
-                    buttonSize="sm"
-                    buttonVariant="ghost"
-                    context={{
-                      title: form.getFieldValue('title') || '',
-                      description: form.getFieldValue('description') || '',
-                    }}
-                    description="Generate complete blog post content"
-                    label="Generate Content"
-                    onApply={(content) => {
-                      field.handleChange(content.trim());
-                    }}
-                    type="content"
-                  />
-                </div>
-              </div>
-              <FormMDXEditor
-                field={field}
-                label=""
-                placeholder="# Article Details
+          <Card>
+            <CardHeader>
+              <CardTitle>Content</CardTitle>
+              <CardDescription>Write the full details of your article.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="content">
+                {(field) => (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                        Content
+                      </span>
+                      <div className="flex gap-2">
+                        <AIAssistDialog
+                          buttonSize="sm"
+                          buttonVariant="ghost"
+                          context={{
+                            title: form.getFieldValue('title') || '',
+                            description: form.getFieldValue('description') || '',
+                          }}
+                          description="Create a detailed outline for your blog post"
+                          label="Create Outline"
+                          onApply={(content) => {
+                            field.handleChange(content.trim());
+                          }}
+                          type="outline"
+                        />
+                        <AIAssistDialog
+                          buttonSize="sm"
+                          buttonVariant="ghost"
+                          context={{
+                            title: form.getFieldValue('title') || '',
+                            description: form.getFieldValue('description') || '',
+                          }}
+                          description="Generate complete blog post content"
+                          label="Generate Content"
+                          onApply={(content) => {
+                            field.handleChange(content.trim());
+                          }}
+                          type="content"
+                        />
+                      </div>
+                    </div>
+                    <FormMDXEditor
+                      field={field}
+                      label=""
+                      placeholder="# Article Details
 ## Overview
 A brief overview of your article."
-              />
-            </div>
-          )}
-        </form.AppField>
+                    />
+                  </div>
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+        </div>
 
-        <form.AppField name="thumbnail">
-          {(field) => (
-            <FormImageUpload
-              field={field as FormField}
-              initialPreview={article?.imageUrl}
-              label="Image"
-              name={field.name}
-            />
-          )}
-        </form.AppField>
+        <div className="flex flex-col gap-6 lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Media</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="thumbnail">
+                {(field) => (
+                  <FormImageUpload
+                    field={field as FormField}
+                    initialPreview={article?.imageUrl}
+                    label="Image"
+                    name={field.name}
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <form.AppField name="tags">
-          {(field) => (
-            <FormMultiSelect
-              field={field}
-              label="Tags"
-              options={Object.entries(STACKS).map(([key, value]) => ({
-                label: key,
-                value: key,
-                icon: <Icon className="h-4 w-4" icon={value} />,
-              }))}
-              placeholder="Select tags"
-            />
-          )}
-        </form.AppField>
+          <Card>
+            <CardHeader>
+              <CardTitle>Taxonomy & Settings</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField name="tags">
+                {(field) => (
+                  <FormMultiSelect
+                    field={field}
+                    label="Tags"
+                    options={Object.entries(STACKS).map(([key, value]) => ({
+                      label: key,
+                      value: key,
+                      icon: <Icon className="h-4 w-4" icon={value} />,
+                    }))}
+                    placeholder="Select tags"
+                  />
+                )}
+              </form.AppField>
 
-        <form.AppField name="isDraft">
-          {(field) => (
-            <FormCheckbox description="This article won't be visible to visitors" field={field} label="Save as Draft" />
-          )}
-        </form.AppField>
+              <form.AppField name="isDraft">
+                {(field) => (
+                  <FormCheckbox
+                    description="This article won't be visible to visitors"
+                    field={field}
+                    label="Save as Draft"
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+        </div>
 
-        <div>
+        <div className="hidden">
           <form.Subscribe selector={(formState) => [formState.canSubmit, formState.isSubmitting]}>
             {([canSubmit, isPending, isSubmitting]) => (
               <FormSubmitButton
                 canSubmit={canSubmit ?? false}
+                id="hidden-submit-btn"
                 isPending={isPending ?? false}
                 isSubmitting={isSubmitting ?? false}
               />
             )}
           </form.Subscribe>
         </div>
-      </>
+      </div>
     );
   },
 });

--- a/apps/dashboard/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/dashboard/src/components/data-table/data-table-toolbar.tsx
@@ -1,36 +1,70 @@
+import type { Table } from '@tanstack/react-table';
 import { Button } from '@xbrk/ui/button';
 import { Input } from '@xbrk/ui/input';
 import { X } from 'lucide-react';
+import type { BulkAction } from './data-table';
 
-interface DataTableToolbarProps {
+interface DataTableToolbarProps<TData> {
+  bulkActions?: BulkAction<TData>[];
   entityName?: string;
   globalFilter: string;
   setGlobalFilter: (value: string) => void;
+  table: Table<TData>;
 }
 
-export function DataTableToolbar({
+export function DataTableToolbar<TData>({
   globalFilter,
   setGlobalFilter,
   entityName = 'items',
-}: Readonly<DataTableToolbarProps>) {
+  table,
+  bulkActions,
+}: Readonly<DataTableToolbarProps<TData>>) {
+  const selectedRows = table.getFilteredSelectedRowModel().rows;
+  const isSelected = selectedRows.length > 0;
+
   return (
     <div className="flex items-center justify-between">
-      <div className="flex flex-1 items-center space-x-2">
-        <Input
-          className="h-8 w-[150px] lg:w-[250px]"
-          onChange={(event) => {
-            setGlobalFilter(String(event.target.value));
-          }}
-          placeholder={`Filter ${entityName}...`}
-          value={globalFilter ?? ''}
-        />
-        {globalFilter && (
-          <Button className="h-8 px-2 lg:px-3" onClick={() => setGlobalFilter('')} variant="ghost">
-            Reset
-            <X />
-          </Button>
-        )}
-      </div>
+      {isSelected && bulkActions ? (
+        <div className="fade-in slide-in-from-left-2 flex flex-1 animate-in items-center space-x-4 duration-200">
+          <span className="whitespace-nowrap font-medium text-muted-foreground text-sm">
+            {selectedRows.length} {selectedRows.length === 1 ? 'item' : 'items'} selected
+          </span>
+          <div className="flex items-center space-x-2">
+            {bulkActions.map((action) => (
+              <Button
+                className="h-8"
+                key={action.label}
+                onClick={() => {
+                  action.onClick(selectedRows.map((row) => row.original));
+                  table.toggleAllRowsSelected(false);
+                }}
+                size="sm"
+                variant={action.variant ?? 'secondary'}
+              >
+                {action.icon}
+                {action.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-1 items-center space-x-2">
+          <Input
+            className="h-8 w-[150px] lg:w-[250px]"
+            onChange={(event) => {
+              setGlobalFilter(String(event.target.value));
+            }}
+            placeholder={`Filter ${entityName}...`}
+            value={globalFilter ?? ''}
+          />
+          {globalFilter && (
+            <Button className="h-8 px-2 lg:px-3" onClick={() => setGlobalFilter('')} variant="ghost">
+              Reset
+              <X />
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/data-table/data-table.tsx
+++ b/apps/dashboard/src/components/data-table/data-table.tsx
@@ -24,7 +24,18 @@ declare module '@tanstack/react-table' {
   }
 }
 
+import { Card } from '@xbrk/ui/card';
+import type { ReactNode } from 'react';
+
+export interface BulkAction<TData> {
+  icon?: ReactNode;
+  label: string;
+  onClick: (rows: TData[]) => void;
+  variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+}
+
 interface DataTableProps<TData, TValue> {
+  bulkActions?: BulkAction<TData>[];
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   entityName?: string;
@@ -46,6 +57,7 @@ export function DataTable<TData, TValue>({
   columns,
   data,
   entityName = 'items',
+  bulkActions,
 }: Readonly<DataTableProps<TData, TValue>>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [rowSelection, setRowSelection] = useState({});
@@ -83,11 +95,17 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div>
-      <div className="py-4">
-        <DataTableToolbar entityName={entityName} globalFilter={globalFilter} setGlobalFilter={setGlobalFilter} />
+    <Card className="flex flex-col border shadow-sm">
+      <div className="border-b p-4">
+        <DataTableToolbar
+          bulkActions={bulkActions}
+          entityName={entityName}
+          globalFilter={globalFilter}
+          setGlobalFilter={setGlobalFilter}
+          table={table}
+        />
       </div>
-      <div className="rounded-md border">
+      <div className="relative w-full overflow-auto">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -126,9 +144,9 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <div className="py-4">
+      <div className="border-t p-4">
         <DataTablePagination pagination={pagination} table={table} />
       </div>
-    </div>
+    </Card>
   );
 }

--- a/apps/dashboard/src/components/data-table/data-table.tsx
+++ b/apps/dashboard/src/components/data-table/data-table.tsx
@@ -88,6 +88,8 @@ export function DataTable<TData, TValue>({
     onColumnFiltersChange: setColumnFilters,
     onRowSelectionChange: setRowSelection,
     autoResetPageIndex: false,
+    // @ts-expect-error fallback id retrieval
+    getRowId: (row) => row.id || row.slug || Math.random().toString(),
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/apps/dashboard/src/components/experiences/form.tsx
+++ b/apps/dashboard/src/components/experiences/form.tsx
@@ -41,7 +41,7 @@ export const ExperiencesForm = withForm({
   },
   render({ form, experience }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
+      <div className="grid gap-6 lg:grid-flow-dense lg:grid-cols-3 lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>

--- a/apps/dashboard/src/components/experiences/form.tsx
+++ b/apps/dashboard/src/components/experiences/form.tsx
@@ -1,6 +1,7 @@
 import { formOptions, type ValidationErrorMap } from '@tanstack/react-form';
 import { ExperienceType as ExperienceTypeEnum, type ExperienceTypeValue } from '@xbrk/db/schema';
 import type { ExperienceType } from '@xbrk/types';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@xbrk/ui/card';
 import { withForm } from '@xbrk/ui/form';
 import {
   FormCheckbox,
@@ -40,100 +41,135 @@ export const ExperiencesForm = withForm({
   },
   render({ form, experience }) {
     return (
-      <>
-        <form.AppField name="title">
-          {(field) => <FormInput field={field} label="Title" placeholder="Software Engineer" required />}
-        </form.AppField>
+      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Experience Details</CardTitle>
+              <CardDescription>Core information about your role and company.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField name="title">
+                {(field) => <FormInput field={field} label="Title" placeholder="Software Engineer" required />}
+              </form.AppField>
 
-        <form.AppField name="institution">
-          {(field) => <FormInput field={field} label="Institution" placeholder="Google" required />}
-        </form.AppField>
+              <form.AppField name="institution">
+                {(field) => <FormInput field={field} label="Institution" placeholder="Google" required />}
+              </form.AppField>
 
-        <form.AppField name="description">
-          {(field) => (
-            <FormTextarea field={field} label="Description" placeholder="A brief description of your project" />
-          )}
-        </form.AppField>
+              <form.AppField name="description">
+                {(field) => (
+                  <FormTextarea
+                    field={field}
+                    label="Description"
+                    placeholder="A brief description of your role and achievements"
+                  />
+                )}
+              </form.AppField>
 
-        <form.AppField name="url">
-          {(field) => <FormInput field={field} label="URL" placeholder="https://www.google.com" type="url" />}
-        </form.AppField>
+              <form.AppField name="url">
+                {(field) => (
+                  <FormInput field={field} label="Company URL" placeholder="https://www.google.com" type="url" />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <form.AppField name="thumbnail">
-          {(field) => (
-            <FormImageUpload
-              field={field as FormField}
-              initialPreview={experience?.imageUrl}
-              label="Image"
-              name={field.name}
-            />
-          )}
-        </form.AppField>
+          <Card>
+            <CardHeader>
+              <CardTitle>Timeline</CardTitle>
+              <CardDescription>When did you work here?</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-8 md:grid-cols-2">
+                <form.AppField name="startDate">
+                  {(field) => <FormDatePicker field={field} label="Start Date" placeholder="Pick a start date" />}
+                </form.AppField>
+                <form.AppField name="endDate">
+                  {(field) => (
+                    <FormDatePicker
+                      disabled={form.getFieldValue('isOnGoing')}
+                      field={field}
+                      label="End Date"
+                      placeholder="Pick an end date"
+                    />
+                  )}
+                </form.AppField>
+              </div>
 
-        <form.AppField name="type">
-          {(field) => (
-            <FormSelect
-              field={field}
-              label="Type"
-              options={Object.values(ExperienceTypeEnum).map((type) => ({
-                value: type,
-                label: type,
-              }))}
-              placeholder="Select a type"
-            />
-          )}
-        </form.AppField>
-
-        <div className="grid gap-8 md:grid-cols-2">
-          <form.AppField name="startDate">
-            {(field) => <FormDatePicker field={field} label="Start Date" placeholder="Pick a start date" />}
-          </form.AppField>
-          <form.AppField name="endDate">
-            {(field) => (
-              <FormDatePicker
-                disabled={form.getFieldValue('isOnGoing')}
-                field={field}
-                label="End Date"
-                placeholder="Pick an end date"
-              />
-            )}
-          </form.AppField>
+              <form.AppField name="isOnGoing">
+                {(field) => (
+                  <FormCheckbox description="This experience is currently ongoing" field={field} label="On Going" />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
         </div>
 
-        <div className="grid gap-8 md:grid-cols-2">
-          <form.AppField name="isOnGoing">
-            {(field) => (
-              <FormCheckbox
-                className=""
-                description="This experience is currently ongoing"
-                field={field}
-                label="On Going"
-              />
-            )}
-          </form.AppField>
-          <form.AppField name="isDraft">
-            {(field) => (
-              <FormCheckbox
-                description="This project won't be visible to visitors"
-                field={field}
-                label="Save as Draft"
-              />
-            )}
-          </form.AppField>
+        <div className="flex flex-col gap-6 lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Logo / Media</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="thumbnail">
+                {(field) => (
+                  <FormImageUpload
+                    field={field as FormField}
+                    initialPreview={experience?.imageUrl}
+                    label="Company Logo"
+                    name={field.name}
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Settings</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField name="type">
+                {(field) => (
+                  <FormSelect
+                    field={field}
+                    label="Type"
+                    options={Object.values(ExperienceTypeEnum).map((type) => ({
+                      value: type,
+                      label: type,
+                    }))}
+                    placeholder="Select a type"
+                  />
+                )}
+              </form.AppField>
+
+              <form.AppField name="isDraft">
+                {(field) => (
+                  <FormCheckbox
+                    description="This experience won't be visible to visitors"
+                    field={field}
+                    label="Save as Draft"
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
         </div>
 
-        <div>
+        <div className="hidden">
           <form.Subscribe selector={(formState) => [formState.canSubmit, formState.isSubmitting]}>
             {([canSubmit, isPending, isSubmitting]) => (
               <FormSubmitButton
                 canSubmit={canSubmit ?? false}
+                id="hidden-submit-btn"
                 isPending={isPending ?? false}
                 isSubmitting={isSubmitting ?? false}
               />
             )}
           </form.Subscribe>
         </div>
-      </>
+      </div>
     );
   },
 });

--- a/apps/dashboard/src/components/experiences/form.tsx
+++ b/apps/dashboard/src/components/experiences/form.tsx
@@ -41,7 +41,7 @@ export const ExperiencesForm = withForm({
   },
   render({ form, experience }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>

--- a/apps/dashboard/src/components/form/input.tsx
+++ b/apps/dashboard/src/components/form/input.tsx
@@ -31,9 +31,13 @@ export function FormInput({
   description,
   className,
 }: Readonly<FormInputProps>) {
+  // If label is explicitly empty string, don't render FormLabel
+  // This allows parent components to completely take over label rendering (like in AI forms)
+  const shouldRenderLabel = label !== '';
+
   return (
     <field.FormItem className={className}>
-      <field.FormLabel>{label}</field.FormLabel>
+      {shouldRenderLabel && <field.FormLabel>{label}</field.FormLabel>}
       <field.FormControl>
         <Input
           aria-describedby={description ? `${field.name}-desc` : undefined}

--- a/apps/dashboard/src/components/form/mdx-editor.tsx
+++ b/apps/dashboard/src/components/form/mdx-editor.tsx
@@ -18,14 +18,17 @@ interface FormMDXEditorProps {
 }
 
 export function FormMDXEditor({ field, label, placeholder, className }: Readonly<FormMDXEditorProps>) {
+  const shouldRenderLabel = label !== '';
   return (
     <div className={className}>
-      <label
-        className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        htmlFor={field.name}
-      >
-        {label}
-      </label>
+      {shouldRenderLabel && (
+        <label
+          className="mb-2 block font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          htmlFor={field.name}
+        >
+          {label}
+        </label>
+      )}
       <Tabs className="w-full" defaultValue="write">
         <TabsList className="mb-2">
           <TabsTrigger value="write">Write</TabsTrigger>

--- a/apps/dashboard/src/components/form/submit-button.tsx
+++ b/apps/dashboard/src/components/form/submit-button.tsx
@@ -1,15 +1,14 @@
 import { Button } from '@xbrk/ui/button';
 
-interface FormSubmitButtonProps {
+import type { ComponentProps } from 'react';
+
+interface FormSubmitButtonProps extends ComponentProps<typeof Button> {
   canSubmit: boolean;
-  className?: string;
   defaultText?: string;
   isPending: boolean;
   isSubmitting: boolean;
   loadingText?: string;
   processingText?: string;
-  size?: 'default' | 'sm' | 'lg' | 'icon';
-  variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
 }
 
 export function FormSubmitButton({
@@ -22,6 +21,7 @@ export function FormSubmitButton({
   variant = 'default',
   size = 'default',
   className = 'w-full md:w-auto',
+  ...props
 }: Readonly<FormSubmitButtonProps>) {
   const buttonText = (() => {
     if (isSubmitting) {
@@ -37,6 +37,7 @@ export function FormSubmitButton({
 
   return (
     <Button
+      {...props}
       className={className}
       disabled={!canSubmit || isPending || isSubmitting}
       size={size}

--- a/apps/dashboard/src/components/form/textarea.tsx
+++ b/apps/dashboard/src/components/form/textarea.tsx
@@ -27,9 +27,10 @@ export function FormTextarea({
   className,
   minHeight = 'min-h-[80px]',
 }: Readonly<FormTextareaProps>) {
+  const shouldRenderLabel = label !== '';
   return (
     <field.FormItem className={className}>
-      <field.FormLabel>{label}</field.FormLabel>
+      {shouldRenderLabel && <field.FormLabel>{label}</field.FormLabel>}
       <field.FormControl>
         <Textarea
           className={minHeight}

--- a/apps/dashboard/src/components/projects/form.tsx
+++ b/apps/dashboard/src/components/projects/form.tsx
@@ -44,7 +44,7 @@ export const ProjectsForm = withForm({
   },
   render({ form, project }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>
@@ -77,7 +77,9 @@ export const ProjectsForm = withForm({
               </form.AppField>
             </CardContent>
           </Card>
+        </div>
 
+        <div className="flex flex-col gap-6 lg:col-span-3">
           <Card>
             <CardHeader>
               <CardTitle>Content</CardTitle>

--- a/apps/dashboard/src/components/projects/form.tsx
+++ b/apps/dashboard/src/components/projects/form.tsx
@@ -44,7 +44,7 @@ export const ProjectsForm = withForm({
   },
   render({ form, project }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
+      <div className="grid gap-6 lg:grid-flow-dense lg:grid-cols-3 lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>

--- a/apps/dashboard/src/components/projects/form.tsx
+++ b/apps/dashboard/src/components/projects/form.tsx
@@ -1,6 +1,7 @@
 import { formOptions, type ValidationErrorMap } from '@tanstack/react-form';
 import { STACKS } from '@xbrk/shared/stack';
 import type { ProjectType } from '@xbrk/types';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@xbrk/ui/card';
 import { withForm } from '@xbrk/ui/form';
 import Icon from '@xbrk/ui/icon';
 import { generateSlug } from '@xbrk/utils';
@@ -43,37 +44,52 @@ export const ProjectsForm = withForm({
   },
   render({ form, project }) {
     return (
-      <>
-        <form.AppField
-          listeners={{
-            onChange: ({ value }) => {
-              const slug = generateSlug(value);
-              form.setFieldValue('slug', slug);
-            },
-          }}
-          name="title"
-        >
-          {(field) => <FormInput field={field} label="Title" placeholder="Portfolio Project" required />}
-        </form.AppField>
+      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>General Information</CardTitle>
+              <CardDescription>The core details of your project.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField
+                listeners={{
+                  onChange: ({ value }) => {
+                    const slug = generateSlug(value);
+                    form.setFieldValue('slug', slug);
+                  },
+                }}
+                name="title"
+              >
+                {(field) => <FormInput field={field} label="Title" placeholder="Portfolio Project" required />}
+              </form.AppField>
 
-        <form.AppField name="slug">
-          {(field) => (
-            <FormSlug field={field} label="Slug" placeholder="portfolio-project" urlPath="/projects/your-slug" />
-          )}
-        </form.AppField>
+              <form.AppField name="slug">
+                {(field) => (
+                  <FormSlug field={field} label="Slug" placeholder="portfolio-project" urlPath="/projects/your-slug" />
+                )}
+              </form.AppField>
 
-        <form.AppField name="description">
-          {(field) => (
-            <FormTextarea field={field} label="Description" placeholder="A brief description of your project" />
-          )}
-        </form.AppField>
+              <form.AppField name="description">
+                {(field) => (
+                  <FormTextarea field={field} label="Description" placeholder="A brief description of your project" />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <form.AppField name="content">
-          {(field) => (
-            <FormMDXEditor
-              field={field}
-              label="Content"
-              placeholder="# Project Details
+          <Card>
+            <CardHeader>
+              <CardTitle>Content</CardTitle>
+              <CardDescription>Write the full details and case study for the project.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="content">
+                {(field) => (
+                  <FormMDXEditor
+                    field={field}
+                    label=""
+                    placeholder="# Project Details
 ## Overview
 A brief overview of your project.
 ## Features
@@ -81,87 +97,111 @@ A brief overview of your project.
 - Feature 2
 ## Implementation
 Details about how you implemented the project."
-            />
-          )}
-        </form.AppField>
-
-        <form.AppField name="thumbnail">
-          {(field) => (
-            <FormImageUpload
-              field={field as FormField}
-              initialPreview={project?.imageUrl}
-              label="Image"
-              name={field.name}
-            />
-          )}
-        </form.AppField>
-
-        <div className="grid gap-8 md:grid-cols-2">
-          <form.AppField name="githubUrl">
-            {(field) => (
-              <FormInput
-                field={field}
-                label="GitHub URL"
-                placeholder="https://github.com/username/project"
-                type="url"
-              />
-            )}
-          </form.AppField>
-
-          <form.AppField name="demoUrl">
-            {(field) => <FormInput field={field} label="Demo URL" placeholder="https://example.com" type="url" />}
-          </form.AppField>
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
         </div>
 
-        <form.AppField name="stacks">
-          {(field) => (
-            <FormMultiSelect
-              field={field}
-              label="Stacks"
-              options={Object.entries(STACKS).map(([key, value]) => ({
-                label: key,
-                value: key,
-                icon: <Icon className="h-4 w-4" icon={value} />,
-              }))}
-              placeholder="Select technology stacks"
-            />
-          )}
-        </form.AppField>
+        <div className="flex flex-col gap-6 lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Media</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="thumbnail">
+                {(field) => (
+                  <FormImageUpload
+                    field={field as FormField}
+                    initialPreview={project?.imageUrl}
+                    label="Image"
+                    name={field.name}
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <div className="grid gap-8 md:grid-cols-2">
-          <form.AppField name="isFeatured">
-            {(field) => (
-              <FormCheckbox
-                description="Display this project in featured section"
-                field={field}
-                label="Featured Project"
-              />
-            )}
-          </form.AppField>
+          <Card>
+            <CardHeader>
+              <CardTitle>Links & Stack</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField name="githubUrl">
+                {(field) => (
+                  <FormInput
+                    field={field}
+                    label="GitHub URL"
+                    placeholder="https://github.com/username/project"
+                    type="url"
+                  />
+                )}
+              </form.AppField>
 
-          <form.AppField name="isDraft">
-            {(field) => (
-              <FormCheckbox
-                description="This project won't be visible to visitors"
-                field={field}
-                label="Save as Draft"
-              />
-            )}
-          </form.AppField>
+              <form.AppField name="demoUrl">
+                {(field) => <FormInput field={field} label="Demo URL" placeholder="https://example.com" type="url" />}
+              </form.AppField>
+
+              <form.AppField name="stacks">
+                {(field) => (
+                  <FormMultiSelect
+                    field={field}
+                    label="Stacks"
+                    options={Object.entries(STACKS).map(([key, value]) => ({
+                      label: key,
+                      value: key,
+                      icon: <Icon className="h-4 w-4" icon={value} />,
+                    }))}
+                    placeholder="Select technology stacks"
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Settings</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField name="isFeatured">
+                {(field) => (
+                  <FormCheckbox
+                    description="Display this project in featured section"
+                    field={field}
+                    label="Featured Project"
+                  />
+                )}
+              </form.AppField>
+
+              <form.AppField name="isDraft">
+                {(field) => (
+                  <FormCheckbox
+                    description="This project won't be visible to visitors"
+                    field={field}
+                    label="Save as Draft"
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
         </div>
 
-        <div>
+        {/* We moved the submit button out of the component to place it in the header instead */}
+        <div className="hidden">
           <form.Subscribe selector={(formState) => [formState.canSubmit, formState.isSubmitting]}>
             {([canSubmit, isPending, isSubmitting]) => (
               <FormSubmitButton
                 canSubmit={canSubmit ?? false}
+                id="hidden-submit-btn"
                 isPending={isPending ?? false}
                 isSubmitting={isSubmitting ?? false}
               />
             )}
           </form.Subscribe>
         </div>
-      </>
+      </div>
     );
   },
 });

--- a/apps/dashboard/src/components/services/form.tsx
+++ b/apps/dashboard/src/components/services/form.tsx
@@ -41,7 +41,7 @@ export const ServicesForm = withForm({
   },
   render({ form, service }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>
@@ -74,7 +74,9 @@ export const ServicesForm = withForm({
               </form.AppField>
             </CardContent>
           </Card>
+        </div>
 
+        <div className="flex flex-col gap-6 lg:col-span-3">
           <Card>
             <CardHeader>
               <CardTitle>Content</CardTitle>

--- a/apps/dashboard/src/components/services/form.tsx
+++ b/apps/dashboard/src/components/services/form.tsx
@@ -41,7 +41,7 @@ export const ServicesForm = withForm({
   },
   render({ form, service }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
+      <div className="grid gap-6 lg:grid-flow-dense lg:grid-cols-3 lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>

--- a/apps/dashboard/src/components/services/form.tsx
+++ b/apps/dashboard/src/components/services/form.tsx
@@ -1,6 +1,7 @@
 import { formOptions, type ValidationErrorMap } from '@tanstack/react-form';
 import { STACKS } from '@xbrk/shared/stack';
 import type { ServiceType } from '@xbrk/types';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@xbrk/ui/card';
 import { withForm } from '@xbrk/ui/form';
 import Icon from '@xbrk/ui/icon';
 import { generateSlug } from '@xbrk/utils';
@@ -40,37 +41,52 @@ export const ServicesForm = withForm({
   },
   render({ form, service }) {
     return (
-      <>
-        <form.AppField
-          listeners={{
-            onChange: ({ value }) => {
-              const slug = generateSlug(value);
-              form.setFieldValue('slug', slug);
-            },
-          }}
-          name="title"
-        >
-          {(field) => <FormInput field={field} label="Title" placeholder="Portfolio Service" required />}
-        </form.AppField>
+      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Service Details</CardTitle>
+              <CardDescription>Core information about your offering.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField
+                listeners={{
+                  onChange: ({ value }) => {
+                    const slug = generateSlug(value);
+                    form.setFieldValue('slug', slug);
+                  },
+                }}
+                name="title"
+              >
+                {(field) => <FormInput field={field} label="Title" placeholder="Portfolio Service" required />}
+              </form.AppField>
 
-        <form.AppField name="slug">
-          {(field) => (
-            <FormSlug field={field} label="Slug" placeholder="portfolio-service" urlPath="/services/your-slug" />
-          )}
-        </form.AppField>
+              <form.AppField name="slug">
+                {(field) => (
+                  <FormSlug field={field} label="Slug" placeholder="portfolio-service" urlPath="/services/your-slug" />
+                )}
+              </form.AppField>
 
-        <form.AppField name="description">
-          {(field) => (
-            <FormTextarea field={field} label="Description" placeholder="A brief description of your service" />
-          )}
-        </form.AppField>
+              <form.AppField name="description">
+                {(field) => (
+                  <FormTextarea field={field} label="Description" placeholder="A brief description of your service" />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <form.AppField name="content">
-          {(field) => (
-            <FormMDXEditor
-              field={field}
-              label="Content"
-              placeholder="# Service Details
+          <Card>
+            <CardHeader>
+              <CardTitle>Content</CardTitle>
+              <CardDescription>Provide the full details for this service.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="content">
+                {(field) => (
+                  <FormMDXEditor
+                    field={field}
+                    label=""
+                    placeholder="# Service Details
 ## Overview
 A brief overview of your service.
 ## Features
@@ -78,54 +94,78 @@ A brief overview of your service.
 - Feature 2
 ## Details
 Details about your service."
-            />
-          )}
-        </form.AppField>
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+        </div>
 
-        <form.AppField name="thumbnail">
-          {(field) => (
-            <FormImageUpload
-              field={field as FormField}
-              initialPreview={service?.imageUrl}
-              label="Image"
-              name={field.name}
-            />
-          )}
-        </form.AppField>
+        <div className="flex flex-col gap-6 lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Media</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="thumbnail">
+                {(field) => (
+                  <FormImageUpload
+                    field={field as FormField}
+                    initialPreview={service?.imageUrl}
+                    label="Image"
+                    name={field.name}
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <form.AppField name="stacks">
-          {(field) => (
-            <FormMultiSelect
-              field={field}
-              label="Stacks"
-              options={Object.entries(STACKS).map(([key, value]) => ({
-                label: key,
-                value: key,
-                icon: <Icon className="h-4 w-4" icon={value} />,
-              }))}
-              placeholder="Select technology stacks"
-            />
-          )}
-        </form.AppField>
+          <Card>
+            <CardHeader>
+              <CardTitle>Taxonomy & Settings</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField name="stacks">
+                {(field) => (
+                  <FormMultiSelect
+                    field={field}
+                    label="Stacks"
+                    options={Object.entries(STACKS).map(([key, value]) => ({
+                      label: key,
+                      value: key,
+                      icon: <Icon className="h-4 w-4" icon={value} />,
+                    }))}
+                    placeholder="Select technology stacks"
+                  />
+                )}
+              </form.AppField>
 
-        <form.AppField name="isDraft">
-          {(field) => (
-            <FormCheckbox description="This service won't be visible to visitors" field={field} label="Save as Draft" />
-          )}
-        </form.AppField>
+              <form.AppField name="isDraft">
+                {(field) => (
+                  <FormCheckbox
+                    description="This service won't be visible to visitors"
+                    field={field}
+                    label="Save as Draft"
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+        </div>
 
-        <div>
+        <div className="hidden">
           <form.Subscribe selector={(formState) => [formState.canSubmit, formState.isSubmitting]}>
             {([canSubmit, isPending, isSubmitting]) => (
               <FormSubmitButton
                 canSubmit={canSubmit ?? false}
+                id="hidden-submit-btn"
                 isPending={isPending ?? false}
                 isSubmitting={isSubmitting ?? false}
               />
             )}
           </form.Subscribe>
         </div>
-      </>
+      </div>
     );
   },
 });

--- a/apps/dashboard/src/components/sidebar.tsx
+++ b/apps/dashboard/src/components/sidebar.tsx
@@ -78,7 +78,7 @@ export function DashboardSidebar({ user }: Readonly<{ user: UserType }>) {
   const currentPath = router.location.pathname;
 
   return (
-    <Sidebar collapsible="icon">
+    <Sidebar collapsible="icon" variant="inset">
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>

--- a/apps/dashboard/src/components/snippets/form.tsx
+++ b/apps/dashboard/src/components/snippets/form.tsx
@@ -19,7 +19,7 @@ export const SnippetsForm = withForm({
   ...snippetFormOpts,
   render({ form }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
+      <div className="grid gap-6 lg:grid-flow-dense lg:grid-cols-3 lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>

--- a/apps/dashboard/src/components/snippets/form.tsx
+++ b/apps/dashboard/src/components/snippets/form.tsx
@@ -19,7 +19,7 @@ export const SnippetsForm = withForm({
   ...snippetFormOpts,
   render({ form }) {
     return (
-      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+      <div className="grid gap-6 lg:grid-cols-3 lg:grid-flow-dense lg:gap-8">
         <div className="flex flex-col gap-6 lg:col-span-2">
           <Card>
             <CardHeader>
@@ -52,7 +52,9 @@ export const SnippetsForm = withForm({
               </form.AppField>
             </CardContent>
           </Card>
+        </div>
 
+        <div className="flex flex-col gap-6 lg:col-span-3">
           <Card>
             <CardHeader>
               <CardTitle>Code Content</CardTitle>

--- a/apps/dashboard/src/components/snippets/form.tsx
+++ b/apps/dashboard/src/components/snippets/form.tsx
@@ -1,4 +1,5 @@
 import { formOptions } from '@tanstack/react-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@xbrk/ui/card';
 import { withForm } from '@xbrk/ui/form';
 import { generateSlug } from '@xbrk/utils';
 import { FormCheckbox, FormInput, FormMDXEditor, FormSlug, FormSubmitButton, FormTextarea } from '../form';
@@ -18,63 +19,97 @@ export const SnippetsForm = withForm({
   ...snippetFormOpts,
   render({ form }) {
     return (
-      <>
-        <form.AppField
-          listeners={{
-            onChange: ({ value }) => {
-              const slug = generateSlug(value);
-              form.setFieldValue('slug', slug);
-            },
-          }}
-          name="title"
-        >
-          {(field) => <FormInput field={field} label="Title" placeholder="Snippet Title" required />}
-        </form.AppField>
+      <div className="grid gap-6 lg:grid-cols-3 lg:gap-8">
+        <div className="flex flex-col gap-6 lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Snippet Information</CardTitle>
+              <CardDescription>The core details of your code snippet.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField
+                listeners={{
+                  onChange: ({ value }) => {
+                    const slug = generateSlug(value);
+                    form.setFieldValue('slug', slug);
+                  },
+                }}
+                name="title"
+              >
+                {(field) => <FormInput field={field} label="Title" placeholder="Snippet Title" required />}
+              </form.AppField>
 
-        <form.AppField name="slug">
-          {(field) => <FormSlug field={field} label="Slug" placeholder="snippet-title" urlPath="/snippets/your-slug" />}
-        </form.AppField>
+              <form.AppField name="slug">
+                {(field) => (
+                  <FormSlug field={field} label="Slug" placeholder="snippet-title" urlPath="/snippets/your-slug" />
+                )}
+              </form.AppField>
 
-        <form.AppField name="description">
-          {(field) => (
-            <FormTextarea field={field} label="Description" placeholder="A brief description of your snippet" />
-          )}
-        </form.AppField>
+              <form.AppField name="description">
+                {(field) => (
+                  <FormTextarea field={field} label="Description" placeholder="A brief description of your snippet" />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
 
-        <form.AppField name="category">
-          {(field) => <FormInput field={field} label="Category" placeholder="React" required />}
-        </form.AppField>
-
-        <form.AppField name="code">
-          {(field) => (
-            <FormMDXEditor
-              field={field}
-              label="Content"
-              placeholder="```javascript
+          <Card>
+            <CardHeader>
+              <CardTitle>Code Content</CardTitle>
+              <CardDescription>Write the actual snippet code below.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form.AppField name="code">
+                {(field) => (
+                  <FormMDXEditor
+                    field={field}
+                    label=""
+                    placeholder="```javascript
 const add = (a, b) => a + b;
 ```"
-            />
-          )}
-        </form.AppField>
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+        </div>
 
-        <form.AppField name="isDraft">
-          {(field) => (
-            <FormCheckbox description="This snippet won't be visible to visitors" field={field} label="Save as Draft" />
-          )}
-        </form.AppField>
+        <div className="flex flex-col gap-6 lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <CardTitle>Classification & Settings</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <form.AppField name="category">
+                {(field) => <FormInput field={field} label="Category" placeholder="React" required />}
+              </form.AppField>
 
-        <div>
+              <form.AppField name="isDraft">
+                {(field) => (
+                  <FormCheckbox
+                    description="This snippet won't be visible to visitors"
+                    field={field}
+                    label="Save as Draft"
+                  />
+                )}
+              </form.AppField>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="hidden">
           <form.Subscribe selector={(formState) => [formState.canSubmit, formState.isSubmitting]}>
             {([canSubmit, isPending, isSubmitting]) => (
               <FormSubmitButton
                 canSubmit={canSubmit ?? false}
+                id="hidden-submit-btn"
                 isPending={isPending ?? false}
                 isSubmitting={isSubmitting ?? false}
               />
             )}
           </form.Subscribe>
         </div>
-      </>
+      </div>
     );
   },
 });

--- a/apps/dashboard/src/lib/utils/columns.tsx
+++ b/apps/dashboard/src/lib/utils/columns.tsx
@@ -28,19 +28,23 @@ export function createCommonColumns<T extends BaseItemType>(
     {
       id: 'select',
       header: ({ table }) => (
-        <Checkbox
-          aria-label={`Select all ${entityName}`}
-          checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
-          onCheckedChange={(value) => table.toggleAllPageRowsSelected(Boolean(value))}
-        />
+        <div className="pl-4">
+          <Checkbox
+            aria-label={`Select all ${entityName}`}
+            checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(Boolean(value))}
+          />
+        </div>
       ),
       cell: ({ row }) => (
-        <Checkbox
-          aria-label={`Select ${row.original.title}`}
-          checked={row.getIsSelected()}
-          disabled={!row.getCanSelect()}
-          onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
-        />
+        <div className="pl-4">
+          <Checkbox
+            aria-label={`Select ${row.original.title}`}
+            checked={row.getIsSelected()}
+            disabled={!row.getCanSelect()}
+            onCheckedChange={(value) => row.toggleSelected(Boolean(value))}
+          />
+        </div>
       ),
       enableSorting: false,
       enableHiding: false,

--- a/apps/dashboard/src/lib/utils/columns.tsx
+++ b/apps/dashboard/src/lib/utils/columns.tsx
@@ -1,6 +1,8 @@
 import { Link } from '@tanstack/react-router';
 import { type ColumnDef } from '@tanstack/react-table';
+import { Badge } from '@xbrk/ui/badge';
 import { Checkbox } from '@xbrk/ui/checkbox';
+import { Star } from 'lucide-react';
 import { DataTableColumnHeader } from '@/components/data-table/data-table-column-header';
 
 export interface BaseItemType {
@@ -68,14 +70,22 @@ export function createCommonColumns<T extends BaseItemType>(
     },
     {
       accessorKey: 'isDraft',
-      header: ({ column }) => <DataTableColumnHeader column={column} title="Draft" />,
-      cell: ({ row }) => (
-        <Checkbox
-          aria-label={`${row.original.title} is draft: ${row.original.isDraft ? 'Yes' : 'No'}`}
-          checked={row.original.isDraft}
-          disabled
-        />
-      ),
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+      cell: ({ row }) => {
+        const isDraft = row.original.isDraft;
+        return (
+          <Badge
+            className={
+              isDraft
+                ? 'bg-yellow-100 text-yellow-800 hover:bg-yellow-100 dark:bg-yellow-900/30 dark:text-yellow-500'
+                : 'bg-green-100 text-green-800 hover:bg-green-100 dark:bg-green-900/30 dark:text-green-500'
+            }
+            variant={isDraft ? 'secondary' : 'default'}
+          >
+            {isDraft ? 'Draft' : 'Published'}
+          </Badge>
+        );
+      },
     },
   ];
 }
@@ -89,13 +99,19 @@ export function createToggleColumn<T extends { title: string }>(
     header: ({ column }) => <DataTableColumnHeader column={column} title={title} />,
     cell: ({ row }) => {
       const value = row.original[accessorKey] as unknown as boolean;
-      return (
-        <Checkbox
-          aria-label={`${row.original.title} is ${title.toLowerCase()}: ${value ? 'Yes' : 'No'}`}
-          checked={value}
-          disabled
-        />
-      );
+
+      if (accessorKey === 'isFeatured') {
+        return (
+          <div className="flex w-full items-center justify-center">
+            <Star
+              aria-label={`${row.original.title} is featured: ${value ? 'Yes' : 'No'}`}
+              className={`h-4 w-4 ${value ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground/30'}`}
+            />
+          </div>
+        );
+      }
+
+      return <Badge variant={value ? 'default' : 'secondary'}>{value ? 'Yes' : 'No'}</Badge>;
     },
   };
 }

--- a/apps/dashboard/src/routes/(dashboard)/blog/$articleId.edit.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/blog/$articleId.edit.tsx
@@ -1,11 +1,14 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, ErrorComponent, useRouter } from '@tanstack/react-router';
 import { ArticleBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
 import { NotFound } from '@xbrk/ui/not-found';
+import { ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ArticleForm } from '@/components/blog/form';
+import { env } from '@/lib/env/client';
 import { queryKeys } from '@/lib/query-keys';
 import { $getArticleById, $updateArticle } from '@/lib/server/blog';
 
@@ -84,14 +87,40 @@ function ArticlesEditPage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Edit Article</h2>
-          <p className="text-muted-foreground">Edit an article here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Edit Article</h2>
+          <p className="text-muted-foreground">Update your existing blog article.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {env.VITE_APP_URL && article.data?.slug && (
+            <Button asChild variant="ghost">
+              <a href={`${env.VITE_APP_URL}/blog/${article.data.slug}`} rel="noopener noreferrer" target="_blank">
+                <ExternalLink className="mr-2 h-4 w-4" />
+                View Live
+              </a>
+            </Button>
+          )}
+          <Button onClick={() => router.navigate({ to: '/blog' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Save Changes
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -105,6 +134,6 @@ function ArticlesEditPage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/blog/create.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/blog/create.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { ArticleBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ArticleForm } from '@/components/blog/form';
@@ -60,14 +62,32 @@ function ArticlesCreatePage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Create Article</h2>
-          <p className="text-muted-foreground">Create a new article here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Create Article</h2>
+          <p className="text-muted-foreground">Draft a new article for your blog.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => router.navigate({ to: '/blog' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create Article
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -81,6 +101,6 @@ function ArticlesCreatePage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/blog/create.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/blog/create.tsx
@@ -63,7 +63,7 @@ function ArticlesCreatePage() {
 
   return (
     <div className="space-y-6 pb-20">
-      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
+      <div className="sticky top-16 z-10 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 py-4 backdrop-blur">
         <div>
           <h2 className="font-bold text-3xl tracking-tight">Create Article</h2>
           <p className="text-muted-foreground">Draft a new article for your blog.</p>

--- a/apps/dashboard/src/routes/(dashboard)/blog/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/blog/index.tsx
@@ -1,16 +1,17 @@
 import { ErrorBoundary } from '@sentry/tanstackstart-react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
 import { Card } from '@xbrk/ui/card';
 import { Skeleton } from '@xbrk/ui/skeleton';
-import { Plus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { blogColumns } from '@/components/blog/columns';
 import { DataTable } from '@/components/data-table/data-table';
 import { queryKeys } from '@/lib/query-keys';
-import { $getAllArticles } from '@/lib/server/blog';
+import { $deleteArticle, $getAllArticles } from '@/lib/server/blog';
 
 export const Route = createFileRoute('/(dashboard)/blog/')({
   component: Articles,
@@ -48,6 +49,7 @@ function ArticlesError() {
 }
 
 function ArticlesContent() {
+  const queryClient = useQueryClient();
   const {
     data: articles,
     error,
@@ -58,6 +60,31 @@ function ArticlesContent() {
     queryFn: () => $getAllArticles(),
   });
 
+  const deleteArticleMutation = useMutation({
+    mutationFn: async (ids: string[]) => {
+      await Promise.all(ids.map((id) => $deleteArticle({ data: id })));
+    },
+    onSuccess: async (_, ids) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.blog.all });
+      toast.success(`Successfully deleted ${ids.length} article${ids.length === 1 ? '' : 's'}.`);
+    },
+    onError: () => {
+      toast.error('Failed to delete selected articles.');
+    },
+  });
+
+  const bulkActions = [
+    {
+      label: 'Delete Selected',
+      icon: <Trash2 className="mr-2 h-4 w-4" />,
+      variant: 'destructive' as const,
+      onClick: (selectedRows: typeof articles) => {
+        const ids = selectedRows.map((row) => row.id);
+        deleteArticleMutation.mutate(ids);
+      },
+    },
+  ];
+
   if (error) {
     return <ArticlesError />;
   }
@@ -66,28 +93,28 @@ function ArticlesContent() {
     return <ArticlesLoading />;
   }
 
-  return <DataTable columns={blogColumns} data={articles} entityName="articles" />;
+  return <DataTable bulkActions={bulkActions} columns={blogColumns} data={articles} entityName="articles" />;
 }
 
 function Articles() {
   return (
-    <>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Article List</h2>
-          <p className="text-muted-foreground">Manage your articles here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Articles</h2>
+          <p className="text-muted-foreground">Manage and organize your blog articles.</p>
         </div>
         <Link
           aria-label="Add new article"
           className={cn(buttonVariants({ variant: 'default' }), 'group')}
           to="/blog/create"
         >
-          <span>Add Article</span> <Plus className="ml-1" size={18} />
+          <Plus className="mr-2" size={16} /> <span>New Article</span>
         </Link>
       </div>
       <ErrorBoundary fallback={<ArticlesError />}>
         <ArticlesContent />
       </ErrorBoundary>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/experiences/$experienceId.edit.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/experiences/$experienceId.edit.tsx
@@ -1,8 +1,10 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, ErrorComponent, useRouter } from '@tanstack/react-router';
 import { ExperienceBaseSchema, ExperienceType, type ExperienceTypeValue } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
 import { NotFound } from '@xbrk/ui/not-found';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ExperiencesForm } from '@/components/experiences/form';
@@ -89,14 +91,32 @@ function ExperiencesEditPage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Edit Experience</h2>
-          <p className="text-muted-foreground">Edit an experience here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Edit Experience</h2>
+          <p className="text-muted-foreground">Update your existing experience details.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => router.navigate({ to: '/experiences' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Save Changes
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -110,6 +130,6 @@ function ExperiencesEditPage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/experiences/create.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/experiences/create.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { ExperienceBaseSchema, ExperienceType, type ExperienceTypeValue } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ExperiencesForm } from '@/components/experiences/form';
@@ -60,14 +62,32 @@ function ExperiencesCreatePage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Create Experience</h2>
-          <p className="text-muted-foreground">Create a new experience here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Create Experience</h2>
+          <p className="text-muted-foreground">Add a new work or educational experience.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => router.navigate({ to: '/experiences' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create Experience
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -81,6 +101,6 @@ function ExperiencesCreatePage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/experiences/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/experiences/index.tsx
@@ -1,16 +1,17 @@
 import { ErrorBoundary } from '@sentry/tanstackstart-react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
 import { Card } from '@xbrk/ui/card';
 import { Skeleton } from '@xbrk/ui/skeleton';
-import { Plus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { DataTable } from '@/components/data-table/data-table';
 import { experienceColumns } from '@/components/experiences/columns';
 import { queryKeys } from '@/lib/query-keys';
-import { $getAllExperiences } from '@/lib/server/experience';
+import { $deleteExperience, $getAllExperiences } from '@/lib/server/experience';
 
 export const Route = createFileRoute('/(dashboard)/experiences/')({
   component: Experiences,
@@ -48,6 +49,7 @@ function ExperiencesError() {
 }
 
 function ExperiencesContent() {
+  const queryClient = useQueryClient();
   const {
     data: experiences,
     error,
@@ -57,6 +59,31 @@ function ExperiencesContent() {
     queryKey: queryKeys.experience.listAll(),
     queryFn: () => $getAllExperiences(),
   });
+
+  const deleteExperienceMutation = useMutation({
+    mutationFn: async (ids: string[]) => {
+      await Promise.all(ids.map((id) => $deleteExperience({ data: id })));
+    },
+    onSuccess: async (_, ids) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.experience.all });
+      toast.success(`Successfully deleted ${ids.length} experience${ids.length === 1 ? '' : 's'}.`);
+    },
+    onError: () => {
+      toast.error('Failed to delete selected experiences.');
+    },
+  });
+
+  const bulkActions = [
+    {
+      label: 'Delete Selected',
+      icon: <Trash2 className="mr-2 h-4 w-4" />,
+      variant: 'destructive' as const,
+      onClick: (selectedRows: typeof experiences) => {
+        const ids = selectedRows.map((row) => row.id);
+        deleteExperienceMutation.mutate(ids);
+      },
+    },
+  ];
 
   if (error) {
     return (
@@ -73,28 +100,30 @@ function ExperiencesContent() {
     return <ExperiencesLoading />;
   }
 
-  return <DataTable columns={experienceColumns} data={experiences} entityName="experiences" />;
+  return (
+    <DataTable bulkActions={bulkActions} columns={experienceColumns} data={experiences} entityName="experiences" />
+  );
 }
 
 function Experiences() {
   return (
-    <>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Experience List</h2>
-          <p className="text-muted-foreground">Manage your experiences here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Experiences</h2>
+          <p className="text-muted-foreground">Manage and organize your work experiences.</p>
         </div>
         <Link
           aria-label="Add new experience"
           className={cn(buttonVariants({ variant: 'default' }), 'group')}
           to="/experiences/create"
         >
-          <span>Add Experience</span> <Plus className="ml-1" size={18} />
+          <Plus className="mr-2" size={16} /> <span>New Experience</span>
         </Link>
       </div>
       <ErrorBoundary fallback={<ExperiencesError />}>
         <ExperiencesContent />
       </ErrorBoundary>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/index.tsx
@@ -32,15 +32,21 @@ export const Route = createFileRoute('/(dashboard)/')({
 
 function DashboardIndex() {
   return (
-    <div className="flex-1 space-y-4">
-      <OverviewCards />
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
-        <div className="col-span-4 space-y-4">
-          <UsersStats />
-          <BlogViewsStats />
-        </div>
-        <div className="col-span-3">
-          <RecentActivity />
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2">
+        <h2 className="font-bold text-3xl tracking-tight">Dashboard</h2>
+        <p className="text-muted-foreground">Overview of your portfolio and site performance.</p>
+      </div>
+      <div className="flex-1 space-y-6">
+        <OverviewCards />
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-7">
+          <div className="col-span-4 space-y-6">
+            <UsersStats />
+            <BlogViewsStats />
+          </div>
+          <div className="col-span-3">
+            <RecentActivity />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/routes/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/layout.tsx
@@ -108,8 +108,8 @@ function LayoutComponent() {
   return (
     <SidebarProvider>
       <DashboardSidebar user={user as UserType} />
-      <SidebarInset>
-        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+      <SidebarInset className="bg-muted/30">
+        <header className="sticky top-0 z-10 flex h-16 shrink-0 items-center gap-2 border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <SidebarTrigger className="-ml-1" />
           <Separator className="mr-2 h-4" orientation="vertical" />
           <Breadcrumb>
@@ -134,8 +134,8 @@ function LayoutComponent() {
             </BreadcrumbList>
           </Breadcrumb>
         </header>
-        <main className="flex flex-1 flex-col gap-4 p-4 pt-0">
-          <div className="mx-auto w-full max-w-6xl py-6">
+        <main className="flex flex-1 flex-col gap-4 p-6 pt-4">
+          <div className="mx-auto w-full max-w-7xl">
             <Outlet />
           </div>
         </main>

--- a/apps/dashboard/src/routes/(dashboard)/projects/$projectId.edit.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/projects/$projectId.edit.tsx
@@ -1,11 +1,14 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, ErrorComponent, useRouter } from '@tanstack/react-router';
 import { ProjectBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
 import { NotFound } from '@xbrk/ui/not-found';
+import { ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ProjectsForm } from '@/components/projects/form';
+import { env } from '@/lib/env/client';
 import { queryKeys } from '@/lib/query-keys';
 import { $getProjectById, $updateProject } from '@/lib/server/project';
 
@@ -87,14 +90,40 @@ function ProjectsEditPage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Edit Project</h2>
-          <p className="text-muted-foreground">Edit a project here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Edit Project</h2>
+          <p className="text-muted-foreground">Update your existing project details.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {env.VITE_APP_URL && project.data?.slug && (
+            <Button asChild variant="ghost">
+              <a href={`${env.VITE_APP_URL}/projects/${project.data.slug}`} rel="noopener noreferrer" target="_blank">
+                <ExternalLink className="mr-2 h-4 w-4" />
+                View Live
+              </a>
+            </Button>
+          )}
+          <Button onClick={() => router.navigate({ to: '/projects' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Save Changes
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -108,6 +137,6 @@ function ProjectsEditPage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/projects/create.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/projects/create.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { ProjectBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ProjectsForm } from '@/components/projects/form';
@@ -58,14 +60,32 @@ function ProjectsCreatePage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Create Project</h2>
-          <p className="text-muted-foreground">Create a new project here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Create Project</h2>
+          <p className="text-muted-foreground">Set up a new project for your portfolio.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => router.navigate({ to: '/projects' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create Project
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -79,6 +99,6 @@ function ProjectsCreatePage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/projects/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/projects/index.tsx
@@ -1,16 +1,17 @@
 import { ErrorBoundary } from '@sentry/tanstackstart-react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
 import { Card } from '@xbrk/ui/card';
 import { Skeleton } from '@xbrk/ui/skeleton';
-import { Plus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { DataTable } from '@/components/data-table/data-table';
 import { projectColumns } from '@/components/projects/columns';
 import { queryKeys } from '@/lib/query-keys';
-import { $getAllProjects } from '@/lib/server/project';
+import { $deleteProject, $getAllProjects } from '@/lib/server/project';
 
 export const Route = createFileRoute('/(dashboard)/projects/')({
   component: Projects,
@@ -48,6 +49,7 @@ function ProjectsError() {
 }
 
 function ProjectsContent() {
+  const queryClient = useQueryClient();
   const {
     data: projects,
     error,
@@ -57,6 +59,32 @@ function ProjectsContent() {
     queryKey: queryKeys.project.listAll(),
     queryFn: () => $getAllProjects(),
   });
+
+  const deleteProjectMutation = useMutation({
+    mutationFn: async (ids: string[]) => {
+      // Execute deletions sequentially or in parallel. We'll do parallel.
+      await Promise.all(ids.map((id) => $deleteProject({ data: id })));
+    },
+    onSuccess: async (_, ids) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.project.all });
+      toast.success(`Successfully deleted ${ids.length} project${ids.length === 1 ? '' : 's'}.`);
+    },
+    onError: () => {
+      toast.error('Failed to delete selected projects.');
+    },
+  });
+
+  const bulkActions = [
+    {
+      label: 'Delete Selected',
+      icon: <Trash2 className="mr-2 h-4 w-4" />,
+      variant: 'destructive' as const,
+      onClick: (selectedRows: typeof projects) => {
+        const ids = selectedRows.map((row) => row.id);
+        deleteProjectMutation.mutate(ids);
+      },
+    },
+  ];
 
   if (error) {
     return (
@@ -73,28 +101,28 @@ function ProjectsContent() {
     return <ProjectsLoading />;
   }
 
-  return <DataTable columns={projectColumns} data={projects} entityName="projects" />;
+  return <DataTable bulkActions={bulkActions} columns={projectColumns} data={projects} entityName="projects" />;
 }
 
 function Projects() {
   return (
-    <>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Project List</h2>
-          <p className="text-muted-foreground">Manage your projects here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Projects</h2>
+          <p className="text-muted-foreground">Manage and organize your portfolio projects.</p>
         </div>
         <Link
           aria-label="Add new project"
           className={cn(buttonVariants({ variant: 'default' }), 'group')}
           to="/projects/create"
         >
-          <span>Add Project</span> <Plus className="ml-1" size={18} />
+          <Plus className="mr-2" size={16} /> <span>New Project</span>
         </Link>
       </div>
       <ErrorBoundary fallback={<ProjectsError />}>
         <ProjectsContent />
       </ErrorBoundary>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/services/$serviceId.edit.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/services/$serviceId.edit.tsx
@@ -1,8 +1,10 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, ErrorComponent, useRouter } from '@tanstack/react-router';
 import { ServiceBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
 import { NotFound } from '@xbrk/ui/not-found';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ServicesForm } from '@/components/services/form';
@@ -84,14 +86,32 @@ function ServicesEditPage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Edit Service</h2>
-          <p className="text-muted-foreground">Edit a service here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Edit Service</h2>
+          <p className="text-muted-foreground">Update your existing service details.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => router.navigate({ to: '/services' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Save Changes
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -105,6 +125,6 @@ function ServicesEditPage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/services/create.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/services/create.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { ServiceBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { ServicesForm } from '@/components/services/form';
@@ -55,14 +57,32 @@ function ServicesCreatePage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Create Service</h2>
-          <p className="text-muted-foreground">Create a new service here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Create Service</h2>
+          <p className="text-muted-foreground">Set up a new service for your portfolio.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => router.navigate({ to: '/services' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create Service
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -76,6 +96,6 @@ function ServicesCreatePage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/services/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/services/index.tsx
@@ -1,16 +1,17 @@
 import { ErrorBoundary } from '@sentry/tanstackstart-react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
 import { Card } from '@xbrk/ui/card';
 import { Skeleton } from '@xbrk/ui/skeleton';
-import { Plus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { DataTable } from '@/components/data-table/data-table';
 import { serviceColumns } from '@/components/services/columns';
 import { queryKeys } from '@/lib/query-keys';
-import { $getAllServices } from '@/lib/server/service';
+import { $deleteService, $getAllServices } from '@/lib/server/service';
 
 export const Route = createFileRoute('/(dashboard)/services/')({
   component: Services,
@@ -48,6 +49,7 @@ function ServicesError() {
 }
 
 function ServicesContent() {
+  const queryClient = useQueryClient();
   const {
     data: services,
     error,
@@ -57,6 +59,31 @@ function ServicesContent() {
     queryKey: queryKeys.service.listAll(),
     queryFn: () => $getAllServices(),
   });
+
+  const deleteServiceMutation = useMutation({
+    mutationFn: async (ids: string[]) => {
+      await Promise.all(ids.map((id) => $deleteService({ data: id })));
+    },
+    onSuccess: async (_, ids) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.service.all });
+      toast.success(`Successfully deleted ${ids.length} service${ids.length === 1 ? '' : 's'}.`);
+    },
+    onError: () => {
+      toast.error('Failed to delete selected services.');
+    },
+  });
+
+  const bulkActions = [
+    {
+      label: 'Delete Selected',
+      icon: <Trash2 className="mr-2 h-4 w-4" />,
+      variant: 'destructive' as const,
+      onClick: (selectedRows: typeof services) => {
+        const ids = selectedRows.map((row) => row.id);
+        deleteServiceMutation.mutate(ids);
+      },
+    },
+  ];
 
   if (error) {
     return (
@@ -73,28 +100,28 @@ function ServicesContent() {
     return <ServicesLoading />;
   }
 
-  return <DataTable columns={serviceColumns} data={services} entityName="services" />;
+  return <DataTable bulkActions={bulkActions} columns={serviceColumns} data={services} entityName="services" />;
 }
 
 function Services() {
   return (
-    <>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Service List</h2>
-          <p className="text-muted-foreground">Manage your services here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Services</h2>
+          <p className="text-muted-foreground">Manage and organize your portfolio services.</p>
         </div>
         <Link
           aria-label="Add new service"
           className={cn(buttonVariants({ variant: 'default' }), 'group')}
           to="/services/create"
         >
-          <span>Add Service</span> <Plus className="ml-1" size={18} />
+          <Plus className="mr-2" size={16} /> <span>New Service</span>
         </Link>
       </div>
       <ErrorBoundary fallback={<ServicesError />}>
         <ServicesContent />
       </ErrorBoundary>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/snippets/$snippetId.edit.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/snippets/$snippetId.edit.tsx
@@ -1,11 +1,14 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, ErrorComponent, useRouter } from '@tanstack/react-router';
 import { SnippetBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
 import { NotFound } from '@xbrk/ui/not-found';
+import { ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { SnippetsForm } from '@/components/snippets/form';
+import { env } from '@/lib/env/client';
 import { queryKeys } from '@/lib/query-keys';
 import { $getSnippetById, $updateSnippet } from '@/lib/server/snippet';
 
@@ -83,14 +86,40 @@ function SnippetsEditPage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Edit Snippet</h2>
-          <p className="text-muted-foreground">Edit a snippet here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Edit Snippet</h2>
+          <p className="text-muted-foreground">Update your existing code snippet.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {env.VITE_APP_URL && snippet.data?.slug && (
+            <Button asChild variant="ghost">
+              <a href={`${env.VITE_APP_URL}/snippets/${snippet.data.slug}`} rel="noopener noreferrer" target="_blank">
+                <ExternalLink className="mr-2 h-4 w-4" />
+                View Live
+              </a>
+            </Button>
+          )}
+          <Button onClick={() => router.navigate({ to: '/snippets' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Save Changes
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -104,6 +133,6 @@ function SnippetsEditPage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/snippets/create.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/snippets/create.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 import { SnippetBaseSchema } from '@xbrk/db/schema';
+import { Button } from '@xbrk/ui/button';
 import { useAppForm } from '@xbrk/ui/form';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 import { SnippetsForm } from '@/components/snippets/form';
@@ -54,14 +56,32 @@ function SnippetsCreatePage() {
   });
 
   return (
-    <>
-      <div className="mb-2 flex flex-wrap items-center justify-between space-y-2">
+    <div className="space-y-6 pb-20">
+      <div className="sticky top-16 z-10 -mx-6 mb-6 flex flex-wrap items-center justify-between gap-4 border-b bg-background/95 px-6 py-4 backdrop-blur">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Create Snippet</h2>
-          <p className="text-muted-foreground">Create a new snippet here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Create Snippet</h2>
+          <p className="text-muted-foreground">Draft a new snippet for your portfolio.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button onClick={() => router.navigate({ to: '/snippets' })} variant="outline">
+            Cancel
+          </Button>
+          <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>
+            {([canSubmit, isSubmitting]) => (
+              <Button
+                disabled={!canSubmit}
+                onClick={() => {
+                  form.handleSubmit();
+                }}
+              >
+                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create Snippet
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </div>
-      <div className="py-4">
+      <div>
         <form.AppForm>
           <form
             className="space-y-8"
@@ -75,6 +95,6 @@ function SnippetsCreatePage() {
           </form>
         </form.AppForm>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/snippets/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/snippets/index.tsx
@@ -1,16 +1,17 @@
 import { ErrorBoundary } from '@sentry/tanstackstart-react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { cn } from '@xbrk/ui';
 import { buttonVariants } from '@xbrk/ui/button';
 import { Card } from '@xbrk/ui/card';
 import { Skeleton } from '@xbrk/ui/skeleton';
-import { Plus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { DataTable } from '@/components/data-table/data-table';
 import { snippetColumns } from '@/components/snippets/columns';
 import { queryKeys } from '@/lib/query-keys';
-import { $getAllSnippets } from '@/lib/server/snippet';
+import { $deleteSnippet, $getAllSnippets } from '@/lib/server/snippet';
 
 export const Route = createFileRoute('/(dashboard)/snippets/')({
   component: Snippets,
@@ -48,6 +49,7 @@ function SnippetsError() {
 }
 
 function SnippetsContent() {
+  const queryClient = useQueryClient();
   const {
     data: snippets,
     error,
@@ -57,6 +59,31 @@ function SnippetsContent() {
     queryKey: queryKeys.snippet.listAll(),
     queryFn: () => $getAllSnippets(),
   });
+
+  const deleteSnippetMutation = useMutation({
+    mutationFn: async (ids: string[]) => {
+      await Promise.all(ids.map((id) => $deleteSnippet({ data: id })));
+    },
+    onSuccess: async (_, ids) => {
+      await queryClient.invalidateQueries({ queryKey: queryKeys.snippet.all });
+      toast.success(`Successfully deleted ${ids.length} snippet${ids.length === 1 ? '' : 's'}.`);
+    },
+    onError: () => {
+      toast.error('Failed to delete selected snippets.');
+    },
+  });
+
+  const bulkActions = [
+    {
+      label: 'Delete Selected',
+      icon: <Trash2 className="mr-2 h-4 w-4" />,
+      variant: 'destructive' as const,
+      onClick: (selectedRows: typeof snippets) => {
+        const ids = selectedRows.map((row) => row.id);
+        deleteSnippetMutation.mutate(ids);
+      },
+    },
+  ];
 
   if (error) {
     return (
@@ -73,28 +100,28 @@ function SnippetsContent() {
     return <SnippetsLoading />;
   }
 
-  return <DataTable columns={snippetColumns} data={snippets} entityName="snippets" />;
+  return <DataTable bulkActions={bulkActions} columns={snippetColumns} data={snippets} entityName="snippets" />;
 }
 
 function Snippets() {
   return (
-    <>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">Snippet List</h2>
-          <p className="text-muted-foreground">Manage your snippets here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Snippets</h2>
+          <p className="text-muted-foreground">Manage and organize your code snippets.</p>
         </div>
         <Link
           aria-label="Add new snippet"
           className={cn(buttonVariants({ variant: 'default' }), 'group')}
           to="/snippets/create"
         >
-          <span>Add Snippet</span> <Plus className="ml-1" size={18} />
+          <Plus className="mr-2" size={16} /> <span>New Snippet</span>
         </Link>
       </div>
       <ErrorBoundary fallback={<SnippetsError />}>
         <SnippetsContent />
       </ErrorBoundary>
-    </>
+    </div>
   );
 }

--- a/apps/dashboard/src/routes/(dashboard)/users/index.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/users/index.tsx
@@ -53,16 +53,16 @@ function UsersContent() {
 
 function Users() {
   return (
-    <>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <h2 className="font-bold text-2xl tracking-tight">User List</h2>
-          <p className="text-muted-foreground">Manage your users here.</p>
+          <h2 className="font-bold text-3xl tracking-tight">Users</h2>
+          <p className="text-muted-foreground">Manage and organize your portfolio users.</p>
         </div>
       </div>
       <ErrorBoundary fallback={<UsersError />}>
         <UsersContent />
       </ErrorBoundary>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
This commit introduces a comprehensive redesign of the admin dashboard, transforming it from a basic layout to a modern, feature-rich SaaS interface (inspired by tools like Vercel and Linear).

Key improvements include:
1. **Global Layout**: Transitions to a subtle continuous background with an "inset" collapsible sidebar and a floating, sticky header with backdrop blur.
2. **Two-Column Forms**: Overhauls all Create and Edit forms (Projects, Articles, Snippets, Experiences, Services) to use a 2-column grid layout (content left, meta right) with distinct Card wrappers. Includes a sticky top bar for easy saving without scrolling.
3. **DataTable Enhancements**: Encapsulates DataTables in Cards. Replaces boring disabled boolean checkboxes with sleek, colorful `Badge` components (Draft vs Published) and interactive `Star` icons (Featured).
4. **Bulk Actions**: Implements a dynamic Bulk Action bar in the `DataTableToolbar` that slides in when rows are selected, allowing for bulk "Delete Selected" functionality across all resource types via `Promise.all`.
5. **Quick Actions**: Adds a "View Live" button in the sticky headers of the Edit pages that opens the corresponding frontend asset in a new tab.

---
*PR created automatically by Jules for task [15495080323673431467](https://jules.google.com/task/15495080323673431467) started by @RLukas2*