### PR TITLE
refactor(errors): migrate to typed error system with HttpError hierarchy

### DIFF
--- a/apps/dashboard/src/routes/api/ai/blog-assist/index.ts
+++ b/apps/dashboard/src/routes/api/ai/blog-assist/index.ts
@@ -146,7 +146,7 @@ export const Route = createFileRoute('/api/ai/blog-assist/')({
           const validation = requestSchema.safeParse(payload);
           if (!validation.success) {
             return handleApiError(
-              new ValidationError('Invalid request', { details: validation.error.format() }),
+              new ValidationError('Invalid request', { metadata: { details: validation.error.format() } }),
               request,
             );
           }

--- a/apps/web/src/routes/api/chat/index.ts
+++ b/apps/web/src/routes/api/chat/index.ts
@@ -62,7 +62,7 @@ export const Route = createFileRoute('/api/chat/')({
             console.warn(`[Chat API] Validation failed for IP ${clientIp}:`, validation.error);
             return handleApiError(
               new ValidationError(validation.error || 'Invalid chat request', {
-                details: validation.details,
+                metadata: { details: validation.details },
               }),
               request,
             );

--- a/apps/web/src/routes/api/contact/index.ts
+++ b/apps/web/src/routes/api/contact/index.ts
@@ -66,7 +66,7 @@ export const Route = createFileRoute('/api/contact/')({
           if (!validationResult.success) {
             return handleApiError(
               new ValidationError('Invalid input', {
-                details: validationResult.error.flatten(),
+                metadata: { details: validationResult.error.flatten() },
               }),
               request,
             );

--- a/packages/api/src/services/blog.ts
+++ b/packages/api/src/services/blog.ts
@@ -9,6 +9,7 @@ import {
   type CreateArticleSchema,
   type UpdateArticleSchema,
 } from '@xbrk/db/schema';
+import { InternalServerError, NotFoundError } from '@xbrk/errors';
 import { getTOCFromHast, markdownToHastJson, RENDERING_VERSION } from '@xbrk/md/processor';
 import { and, desc, eq, sql } from 'drizzle-orm';
 import type { z } from 'zod/v4';
@@ -112,14 +113,14 @@ export async function getBySlug(db: DbClient, input: { slug: string }, session?:
       .limit(1);
 
     if (!result[0]) {
-      throw new Error('Article not found');
+      throw new NotFoundError('Article not found');
     }
 
     const { article, viewCount, likesCount } = result[0];
 
     // Check draft access
     if (article.isDraft && session?.user.role !== 'admin') {
-      throw new Error('Article is not public');
+      throw new NotFoundError('Article is not public');
     }
 
     // Fetch related data
@@ -172,15 +173,12 @@ export async function getBySlug(db: DbClient, input: { slug: string }, session?:
       author: articleWithRelations?.author,
     };
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Article not found' || error.message === 'Article is not public')
-    ) {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[blog.getBySlug] Database error:', error);
-    throw new Error('Failed to fetch article');
+    throw new InternalServerError('Failed to fetch article');
   }
 }
 
@@ -305,12 +303,12 @@ export async function like(
     const article = await query.execute({ slug: input.slug });
 
     if (!article) {
-      throw new Error('Article not found');
+      throw new NotFoundError('Article not found');
     }
 
     // if article is draft, throw an error unless user is admin
     if (article.isDraft && session?.user.role !== 'admin') {
-      throw new Error('Article is not public');
+      throw new NotFoundError('Article is not public');
     }
 
     // Extract IP address from headers
@@ -336,15 +334,12 @@ export async function like(
       });
     });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Article not found' || error.message === 'Article is not public')
-    ) {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[blog.like] Database error:', error);
-    throw new Error('Failed to toggle like');
+    throw new InternalServerError('Failed to toggle like');
   }
 }
 
@@ -394,12 +389,12 @@ export async function view(db: DbClient, input: { slug: string }): Promise<void>
     const article = await query.execute({ slug: input.slug });
 
     if (!article) {
-      throw new Error('Article not found');
+      throw new NotFoundError('Article not found');
     }
 
     // if article is draft, throw an error
     if (article.isDraft) {
-      throw new Error('Article is not public');
+      throw new NotFoundError('Article is not public');
     }
 
     // Insert view record with timestamp
@@ -407,14 +402,11 @@ export async function view(db: DbClient, input: { slug: string }): Promise<void>
       articleId: article.id,
     });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Article not found' || error.message === 'Article is not public')
-    ) {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[blog.view] Database error:', error);
-    throw new Error('Failed to record view');
+    throw new InternalServerError('Failed to record view');
   }
 }

--- a/packages/api/src/services/comment.ts
+++ b/packages/api/src/services/comment.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { commentReactions, comments, user } from '@xbrk/db/schema';
+import { ForbiddenError, InternalServerError, NotFoundError } from '@xbrk/errors';
 import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm';
 import { z } from 'zod/v4';
 
@@ -46,7 +47,7 @@ export async function create(
   } catch (error) {
     Sentry.captureException(error);
     console.error('[comment.create] Database error:', error);
-    throw new Error('Failed to create comment');
+    throw new InternalServerError('Failed to create comment');
   }
 }
 
@@ -121,11 +122,11 @@ export async function remove(db: DbClient, input: { id: string }, userId: string
       });
 
       if (!comment) {
-        throw new Error('Comment not found');
+        throw new NotFoundError('Comment not found');
       }
 
       if (comment.userId !== userId && userRole !== 'admin') {
-        throw new Error('You are not allowed to delete this comment');
+        throw new ForbiddenError('You are not allowed to delete this comment');
       }
 
       // Delete child comments first (replies) to avoid foreign key constraint violation
@@ -135,15 +136,12 @@ export async function remove(db: DbClient, input: { id: string }, userId: string
       await tx.delete(comments).where(eq(comments.id, input.id));
     });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Comment not found' || error.message === 'You are not allowed to delete this comment')
-    ) {
+    if (error instanceof NotFoundError || error instanceof ForbiddenError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[comment.remove] Database error:', error);
-    throw new Error('Failed to delete comment');
+    throw new InternalServerError('Failed to delete comment');
   }
 }
 
@@ -162,7 +160,7 @@ export async function react(db: DbClient, input: { id: string; like: boolean }, 
       });
 
       if (!comment) {
-        throw new Error('Comment not found');
+        throw new NotFoundError('Comment not found');
       }
 
       // if (comment.userId === userId) {
@@ -184,14 +182,11 @@ export async function react(db: DbClient, input: { id: string; like: boolean }, 
       }
     });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Comment not found' || error.message === 'You are not allowed to react to your own comment')
-    ) {
+    if (error instanceof NotFoundError || error instanceof ForbiddenError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[comment.react] Database error:', error);
-    throw new Error('Failed to react to comment');
+    throw new InternalServerError('Failed to react to comment');
   }
 }

--- a/packages/api/src/services/experience.ts
+++ b/packages/api/src/services/experience.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { CreateExperienceSchema, experience, UpdateExperienceSchema } from '@xbrk/db/schema';
+import { InternalServerError, NotFoundError } from '@xbrk/errors';
 import { desc, eq, sql } from 'drizzle-orm';
 import type { z } from 'zod/v4';
 import { handleImageUpdate, handleImageUpload } from '../lib/base-service';
@@ -80,7 +81,7 @@ export function create(db: DbClient, input: z.infer<typeof CreateExperienceSchem
     } catch (error) {
       Sentry.captureException(error);
       console.error('[experience.create] Error:', error);
-      throw new Error('Failed to create experience');
+      throw new InternalServerError('Failed to create experience');
     }
   })();
 }
@@ -125,7 +126,7 @@ export function update(db: DbClient, input: z.infer<typeof UpdateExperienceSchem
     } catch (error) {
       Sentry.captureException(error);
       console.error('[experience.update] Error:', error);
-      throw new Error('Failed to update experience');
+      throw new InternalServerError('Failed to update experience');
     }
   });
 }
@@ -139,7 +140,7 @@ export function remove(db: DbClient, id: string) {
       });
 
       if (!experienceToDelete) {
-        throw new Error('Experience not found');
+        throw new NotFoundError('Experience not found');
       }
 
       await tx.delete(experience).where(eq(experience.id, id));
@@ -153,12 +154,12 @@ export function remove(db: DbClient, id: string) {
         }
       }
     } catch (error) {
-      if (error instanceof Error && error.message === 'Experience not found') {
+      if (error instanceof NotFoundError) {
         throw error;
       }
       Sentry.captureException(error);
       console.error('[experience.remove] Error:', error);
-      throw new Error('Failed to delete experience');
+      throw new InternalServerError('Failed to delete experience');
     }
   });
 }

--- a/packages/api/src/services/guestbook.ts
+++ b/packages/api/src/services/guestbook.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { guestbook } from '@xbrk/db/schema';
+import { ForbiddenError, InternalServerError, NotFoundError } from '@xbrk/errors';
 import { desc, eq } from 'drizzle-orm';
 
 type DbClient = typeof DB;
@@ -16,7 +17,7 @@ export async function create(db: DbClient, input: { message: string }, userId: s
   } catch (error) {
     Sentry.captureException(error);
     console.error('[guestbook.create] Database error:', error);
-    throw new Error('Failed to create guestbook entry');
+    throw new InternalServerError('Failed to create guestbook entry');
   }
 }
 
@@ -55,25 +56,21 @@ export async function remove(db: DbClient, input: { id: string }, userId: string
       });
 
       if (!entry) {
-        throw new Error('Guestbook entry not found');
+        throw new NotFoundError('Guestbook entry not found');
       }
 
       if (entry.userId !== userId && userRole !== 'admin') {
-        throw new Error('You are not allowed to delete this guestbook entry');
+        throw new ForbiddenError('You are not allowed to delete this guestbook entry');
       }
 
       await tx.delete(guestbook).where(eq(guestbook.id, input.id));
     });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Guestbook entry not found' ||
-        error.message === 'You are not allowed to delete this guestbook entry')
-    ) {
+    if (error instanceof NotFoundError || error instanceof ForbiddenError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[guestbook.remove] Database error:', error);
-    throw new Error('Failed to delete guestbook entry');
+    throw new InternalServerError('Failed to delete guestbook entry');
   }
 }

--- a/packages/api/src/services/project.ts
+++ b/packages/api/src/services/project.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { CreateProjectSchema, project, UpdateProjectSchema } from '@xbrk/db/schema';
+import { InternalServerError, NotFoundError } from '@xbrk/errors';
 import { getTOCFromHast, markdownToHastJson, RENDERING_VERSION } from '@xbrk/md/processor';
 import { desc, eq, sql } from 'drizzle-orm';
 import type { z } from 'zod/v4';
@@ -52,26 +53,23 @@ export async function getBySlug(db: DbClient, input: { slug: string }, session?:
     const result = await query.execute({ slug: input.slug });
 
     if (!result) {
-      throw new Error('Project not found');
+      throw new NotFoundError('Project not found');
     }
 
     if (result.isDraft && session?.user.role !== 'admin') {
-      throw new Error('Project is not public');
+      throw new NotFoundError('Project is not public');
     }
 
     const toc = getTOCFromHast(result.contentRendering);
 
     return { ...result, toc };
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Project not found' || error.message === 'Project is not public')
-    ) {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[project.getBySlug] Database error:', error);
-    throw new Error('Failed to fetch project');
+    throw new InternalServerError('Failed to fetch project');
   }
 }
 
@@ -89,17 +87,17 @@ export async function getById(db: DbClient, input: { id: string }) {
     const result = await query.execute({ id: input.id });
 
     if (!result) {
-      throw new Error('Project not found');
+      throw new NotFoundError('Project not found');
     }
 
     return result;
   } catch (error) {
-    if (error instanceof Error && error.message === 'Project not found') {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[project.getById] Database error:', error);
-    throw new Error('Failed to fetch project');
+    throw new InternalServerError('Failed to fetch project');
   }
 }
 
@@ -126,7 +124,7 @@ export async function create(db: DbClient, input: z.infer<typeof CreateProjectSc
   } catch (error) {
     Sentry.captureException(error);
     console.error('[project.create] Database error:', error);
-    throw new Error('Failed to create project');
+    throw new InternalServerError('Failed to create project');
   }
 }
 
@@ -169,7 +167,7 @@ export async function update(db: DbClient, input: z.infer<typeof UpdateProjectSc
   } catch (error) {
     Sentry.captureException(error);
     console.error('[project.update] Database error:', error);
-    throw new Error('Failed to update project');
+    throw new InternalServerError('Failed to update project');
   }
 }
 
@@ -185,7 +183,7 @@ export async function remove(db: DbClient, id: string) {
       });
 
       if (!projectToDelete) {
-        throw new Error('Project not found');
+        throw new NotFoundError('Project not found');
       }
 
       await tx.delete(project).where(eq(project.id, id));
@@ -200,11 +198,11 @@ export async function remove(db: DbClient, id: string) {
       }
     });
   } catch (error) {
-    if (error instanceof Error && error.message === 'Project not found') {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[project.remove] Database error:', error);
-    throw new Error('Failed to delete project');
+    throw new InternalServerError('Failed to delete project');
   }
 }

--- a/packages/api/src/services/search.ts
+++ b/packages/api/src/services/search.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { articles, project, snippet } from '@xbrk/db/schema';
+import { ValidationError } from '@xbrk/errors';
 import { and, eq, ilike, or } from 'drizzle-orm';
 import { escapeSearchTerm, validateSearchQuery } from '../lib/validation';
 
@@ -31,7 +32,7 @@ export async function query(db: DbClient, input: { query: string }): Promise<Sea
     // Validate search query
     const validation = validateSearchQuery(input.query);
     if (!validation.valid) {
-      throw new Error(validation.error);
+      throw new ValidationError(validation.error ?? 'Invalid search query');
     }
 
     const searchTerm = `%${escapeSearchTerm(input.query)}%`;
@@ -84,7 +85,7 @@ export async function query(db: DbClient, input: { query: string }): Promise<Sea
       snippets: snippetsResult,
     };
   } catch (error) {
-    if (error instanceof Error && error.message.includes('Search query')) {
+    if (error instanceof ValidationError) {
       throw error;
     }
     Sentry.captureException(error);

--- a/packages/api/src/services/service.ts
+++ b/packages/api/src/services/service.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { CreateServiceSchema, service, UpdateServiceSchema } from '@xbrk/db/schema';
+import { InternalServerError, NotFoundError } from '@xbrk/errors';
 import { markdownToHastJson, RENDERING_VERSION } from '@xbrk/md/processor';
 import { desc, eq, sql } from 'drizzle-orm';
 import type { z } from 'zod/v4';
@@ -51,25 +52,22 @@ export async function getBySlug(db: DbClient, input: { slug: string }, session?:
     const serviceResult = await query.execute({ slug: input.slug });
 
     if (!serviceResult) {
-      throw new Error('Service not found');
+      throw new NotFoundError('Service not found');
     }
 
     // if service is draft, throw an error unless user is admin
     if (serviceResult.isDraft && session?.user.role !== 'admin') {
-      throw new Error('Service is not public');
+      throw new NotFoundError('Service is not public');
     }
 
     return serviceResult;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Service not found' || error.message === 'Service is not public')
-    ) {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[service.getBySlug] Database error:', error);
-    throw new Error('Failed to fetch service');
+    throw new InternalServerError('Failed to fetch service');
   }
 }
 
@@ -112,7 +110,7 @@ export async function create(db: DbClient, input: z.infer<typeof CreateServiceSc
   } catch (error) {
     Sentry.captureException(error);
     console.error('[service.create] Database error:', error);
-    throw new Error('Failed to create service');
+    throw new InternalServerError('Failed to create service');
   }
 }
 
@@ -154,7 +152,7 @@ export function update(db: DbClient, input: z.infer<typeof UpdateServiceSchema>)
     } catch (error) {
       Sentry.captureException(error);
       console.error('[service.update] Database error:', error);
-      throw new Error('Failed to update service');
+      throw new InternalServerError('Failed to update service');
     }
   });
 }
@@ -168,7 +166,7 @@ export function remove(db: DbClient, id: string) {
       });
 
       if (!serviceToDelete) {
-        throw new Error('Service not found');
+        throw new NotFoundError('Service not found');
       }
 
       await tx.delete(service).where(eq(service.id, id));
@@ -182,12 +180,12 @@ export function remove(db: DbClient, id: string) {
         }
       }
     } catch (error) {
-      if (error instanceof Error && error.message === 'Service not found') {
+      if (error instanceof NotFoundError) {
         throw error;
       }
       Sentry.captureException(error);
       console.error('[service.remove] Database error:', error);
-      throw new Error('Failed to delete service');
+      throw new InternalServerError('Failed to delete service');
     }
   });
 }

--- a/packages/api/src/services/snippet.ts
+++ b/packages/api/src/services/snippet.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { CreateSnippetSchema, snippet, UpdateSnippetSchema } from '@xbrk/db/schema';
+import { InternalServerError, NotFoundError } from '@xbrk/errors';
 import { markdownToHastJson, RENDERING_VERSION } from '@xbrk/md/processor';
 import { desc, eq, sql } from 'drizzle-orm';
 import type { z } from 'zod/v4';
@@ -66,24 +67,21 @@ export async function getBySlug(db: DbClient, input: { slug: string }, session?:
     const result = await query.execute({ slug: input.slug });
 
     if (!result) {
-      throw new Error('Snippet not found');
+      throw new NotFoundError('Snippet not found');
     }
 
     if (result.isDraft && session?.user.role !== 'admin') {
-      throw new Error('Snippet is not public');
+      throw new NotFoundError('Snippet is not public');
     }
 
     return result;
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message === 'Snippet not found' || error.message === 'Snippet is not public')
-    ) {
+    if (error instanceof NotFoundError) {
       throw error;
     }
     Sentry.captureException(error);
     console.error('[snippet.getBySlug] Database error:', error);
-    throw new Error('Failed to fetch snippet');
+    throw new InternalServerError('Failed to fetch snippet');
   }
 }
 
@@ -99,7 +97,7 @@ export async function create(db: DbClient, input: z.infer<typeof CreateSnippetSc
   } catch (error) {
     Sentry.captureException(error);
     console.error('[snippet.create] Database error:', error);
-    throw new Error('Failed to create snippet');
+    throw new InternalServerError('Failed to create snippet');
   }
 }
 
@@ -117,7 +115,7 @@ export async function update(db: DbClient, input: z.infer<typeof UpdateSnippetSc
   } catch (error) {
     Sentry.captureException(error);
     console.error('[snippet.update] Database error:', error);
-    throw new Error('Failed to update snippet');
+    throw new InternalServerError('Failed to update snippet');
   }
 }
 
@@ -127,6 +125,6 @@ export async function remove(db: DbClient, id: string) {
   } catch (error) {
     Sentry.captureException(error);
     console.error('[snippet.remove] Database error:', error);
-    throw new Error('Failed to delete snippet');
+    throw new InternalServerError('Failed to delete snippet');
   }
 }

--- a/packages/api/src/services/stats.ts
+++ b/packages/api/src/services/stats.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/node';
 import type { db as DB } from '@xbrk/db/client';
 import { articles, articleViews, project, snippet, user } from '@xbrk/db/schema';
+import { ValidationError } from '@xbrk/errors';
 import { count, desc, sql } from 'drizzle-orm';
 
 type DbClient = typeof DB;
@@ -25,7 +26,7 @@ function validateMonths(months?: number): number {
   }
 
   if (months < MIN_MONTHS || months > MAX_MONTHS) {
-    throw new Error(`Months must be between ${MIN_MONTHS} and ${MAX_MONTHS}`);
+    throw new ValidationError(`Months must be between ${MIN_MONTHS} and ${MAX_MONTHS}`);
   }
 
   return months;
@@ -218,7 +219,7 @@ export async function monthlyBlogViews(db: DbClient, input?: { months?: number }
 
     return processMonthlyData(result, start, months);
   } catch (error) {
-    if (error instanceof Error && error.message.includes('Months must be')) {
+    if (error instanceof ValidationError) {
       throw error;
     }
     Sentry.captureException(error);

--- a/packages/api/src/storage.ts
+++ b/packages/api/src/storage.ts
@@ -1,6 +1,7 @@
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK requires namespace import
 import * as Sentry from '@sentry/node';
 import { del, put } from '@vercel/blob';
+import { InternalServerError, ValidationError } from '@xbrk/errors';
 import { createSlug, isValidBase64 } from './lib/validation';
 
 export const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -17,16 +18,16 @@ const allowedDomains = ['vercel-blob.com', 'blob.vercel-storage.com'];
 export async function uploadImage(folder: string, image: string, slug: string): Promise<string> {
   try {
     if (!image?.trim()) {
-      throw new Error('Invalid image: empty string provided');
+      throw new ValidationError('Invalid image: empty string provided');
     }
 
     if (!isValidBase64(image)) {
-      throw new Error('Invalid base64 format');
+      throw new ValidationError('Invalid base64 format');
     }
 
     const imageSize = Buffer.byteLength(image, 'base64');
     if (imageSize > MAX_IMAGE_SIZE) {
-      throw new Error(
+      throw new ValidationError(
         `Image exceeds maximum allowed size of ${MAX_IMAGE_SIZE / 1024 / 1024}MB (got ${(imageSize / 1024 / 1024).toFixed(2)}MB)`,
       );
     }
@@ -44,7 +45,7 @@ export async function uploadImage(folder: string, image: string, slug: string): 
     return url;
   } catch (_error) {
     Sentry.captureException(_error);
-    throw new Error('Failed to upload image', { cause: _error as Error });
+    throw new InternalServerError('Failed to upload image', { cause: _error as Error });
   }
 }
 
@@ -56,17 +57,17 @@ export async function uploadImage(folder: string, image: string, slug: string): 
 export async function deleteFile(url: string): Promise<void> {
   try {
     if (!url?.trim()) {
-      throw new Error('Invalid URL: empty string provided');
+      throw new ValidationError('Invalid URL: empty string provided');
     }
 
     const urlObj = new URL(url);
     if (!allowedDomains.some((domain) => urlObj.hostname.includes(domain))) {
-      throw new Error('URL does not belong to an allowed storage domain');
+      throw new ValidationError('URL does not belong to an allowed storage domain');
     }
 
     await del(url);
   } catch (_error) {
     Sentry.captureException(_error);
-    throw new Error('Failed to delete file', { cause: _error as Error });
+    throw new InternalServerError('Failed to delete file', { cause: _error as Error });
   }
 }

--- a/packages/api/src/utils/error-handler.ts
+++ b/packages/api/src/utils/error-handler.ts
@@ -1,6 +1,6 @@
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK requires namespace import
 import * as Sentry from '@sentry/node';
-import { AppError, InternalServerError } from '@xbrk/errors';
+import { HttpError, InternalServerError } from '@xbrk/errors';
 import type { ApiErrorResponse } from '../types/error-response';
 
 // Only non-PII headers safe to forward to Sentry
@@ -19,10 +19,10 @@ const isDev = process.env.NODE_ENV === 'development';
 const GENERIC_5XX_MESSAGE = 'An unexpected error occurred';
 
 /**
- * Convert any error to AppError, preserving the original for Sentry.
+ * Convert any error to HttpError, preserving the original for Sentry.
  */
-function toAppError(error: unknown): { appError: AppError; originalError: unknown } {
-  if (error instanceof AppError) {
+function toAppError(error: unknown): { appError: HttpError; originalError: unknown } {
+  if (error instanceof HttpError) {
     return { appError: error, originalError: error };
   }
 

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -1,0 +1,12 @@
+export const ErrorCodes = {
+  VALIDATION: 'VALIDATION_ERROR',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  FORBIDDEN: 'FORBIDDEN',
+  NOT_FOUND: 'NOT_FOUND',
+  CONFLICT: 'CONFLICT',
+  RATE_LIMIT: 'RATE_LIMIT_EXCEEDED',
+  INTERNAL: 'INTERNAL_SERVER_ERROR',
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/packages/errors/src/guards.ts
+++ b/packages/errors/src/guards.ts
@@ -1,0 +1,8 @@
+import { HttpError } from './http-error';
+
+export function isHttpError(error: unknown): error is HttpError {
+  return (
+    error instanceof HttpError ||
+    (error !== null && typeof error === 'object' && 'code' in error && 'statusCode' in error && 'message' in error)
+  );
+}

--- a/packages/errors/src/http-error.ts
+++ b/packages/errors/src/http-error.ts
@@ -1,0 +1,98 @@
+import { type ErrorCode, ErrorCodes } from './codes';
+
+export interface HttpErrorOptions {
+  cause?: Error;
+  metadata?: Record<string, unknown>;
+}
+
+export class HttpError extends Error {
+  readonly code: ErrorCode;
+  readonly statusCode: number;
+  readonly metadata?: Record<string, unknown>;
+
+  constructor(message: string, code: ErrorCode, statusCode: number, options?: HttpErrorOptions) {
+    super(message, { cause: options?.cause });
+    this.name = this.constructor.name;
+    this.code = code;
+    this.statusCode = statusCode;
+    this.metadata = options?.metadata;
+
+    // biome-ignore lint/complexity/noBannedTypes: Error.captureStackTrace requires Function type
+    if (typeof (Error as unknown as { captureStackTrace?: unknown }).captureStackTrace === 'function') {
+      // biome-ignore lint/complexity/noBannedTypes: Error.captureStackTrace requires Function type
+      (Error as unknown as { captureStackTrace: (target: object, constructorOpt: Function) => void }).captureStackTrace(
+        this,
+        this.constructor,
+      );
+    }
+  }
+
+  toJSON(includeStack?: boolean): Record<string, unknown> {
+    const json: Record<string, unknown> = {
+      name: this.name,
+      message: this.message,
+      code: this.code,
+      statusCode: this.statusCode,
+      metadata: this.metadata,
+    };
+    if (includeStack && this.stack) {
+      json.stack = this.stack;
+    }
+    return json;
+  }
+}
+
+export class ValidationError extends HttpError {
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, ErrorCodes.VALIDATION, 400, options);
+  }
+}
+
+export class UnauthorizedError extends HttpError {
+  constructor(message?: string, options?: HttpErrorOptions) {
+    super(message ?? 'Unauthorized', ErrorCodes.UNAUTHORIZED, 401, options);
+  }
+}
+
+export class ForbiddenError extends HttpError {
+  constructor(message?: string, options?: HttpErrorOptions) {
+    super(message ?? 'Forbidden', ErrorCodes.FORBIDDEN, 403, options);
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, ErrorCodes.NOT_FOUND, 404, options);
+  }
+
+  static forResource(resource: string, options?: HttpErrorOptions): NotFoundError {
+    return new NotFoundError(`${resource} not found`, {
+      ...options,
+      metadata: { ...options?.metadata, resource },
+    });
+  }
+}
+
+export class ConflictError extends HttpError {
+  constructor(message: string, options?: HttpErrorOptions) {
+    super(message, ErrorCodes.CONFLICT, 409, options);
+  }
+}
+
+export class RateLimitError extends HttpError {
+  constructor(message?: string, options?: HttpErrorOptions) {
+    super(message ?? 'Too many requests', ErrorCodes.RATE_LIMIT, 429, options);
+  }
+}
+
+export class InternalServerError extends HttpError {
+  constructor(message?: string, options?: HttpErrorOptions) {
+    super(message ?? 'Internal server error', ErrorCodes.INTERNAL, 500, options);
+  }
+}
+
+export class ServiceUnavailableError extends HttpError {
+  constructor(message?: string, options?: HttpErrorOptions) {
+    super(message ?? 'Service temporarily unavailable', ErrorCodes.SERVICE_UNAVAILABLE, 503, options);
+  }
+}

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,116 +1,15 @@
-/**
- * Base Application Error
- * All custom errors should extend this class
- */
-export class AppError extends Error {
-  code: string;
-  statusCode: number;
-  metadata?: Record<string, unknown>;
-
-  constructor(message: string, code: string, statusCode: number, metadata?: Record<string, unknown>) {
-    super(message);
-    this.name = this.constructor.name;
-    this.code = code;
-    this.statusCode = statusCode;
-    this.metadata = metadata;
-
-    // Only use captureStackTrace if available (V8 only, not on edge runtime)
-    if (typeof (Error as unknown as { captureStackTrace?: unknown }).captureStackTrace === 'function') {
-      // biome-ignore lint/complexity/noBannedTypes: Error.captureStackTrace requires Function type
-      (Error as unknown as { captureStackTrace: (target: object, constructorOpt: Function) => void }).captureStackTrace(
-        this,
-        this.constructor,
-      );
-    }
-  }
-
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-      code: this.code,
-      statusCode: this.statusCode,
-      metadata: this.metadata,
-    };
-  }
-}
-
-/**
- * 400 - Bad Request / Validation Error
- * Use when user input is invalid
- */
-export class ValidationError extends AppError {
-  constructor(message: string, metadata?: Record<string, unknown>) {
-    super(message, 'VALIDATION_ERROR', 400, metadata);
-  }
-}
-
-/**
- * 401 - Unauthorized
- * Use when user is not authenticated
- */
-export class UnauthorizedError extends AppError {
-  constructor(message = 'Unauthorized') {
-    super(message, 'UNAUTHORIZED', 401);
-  }
-}
-
-/**
- * 403 - Forbidden
- * Use when user is authenticated but doesn't have permission
- */
-export class ForbiddenError extends AppError {
-  constructor(message = 'Forbidden') {
-    super(message, 'FORBIDDEN', 403);
-  }
-}
-
-/**
- * 404 - Not Found
- * Use when requested resource doesn't exist
- */
-export class NotFoundError extends AppError {
-  constructor(resource: string) {
-    super(`${resource} not found`, 'NOT_FOUND', 404, { resource });
-  }
-}
-
-/**
- * 409 - Conflict
- * Use when there's a conflict (e.g., duplicate entry)
- */
-export class ConflictError extends AppError {
-  constructor(message: string, metadata?: Record<string, unknown>) {
-    super(message, 'CONFLICT', 409, metadata);
-  }
-}
-
-/**
- * 429 - Too Many Requests
- * Use when rate limit is exceeded
- */
-export class RateLimitError extends AppError {
-  constructor(message = 'Too many requests') {
-    super(message, 'RATE_LIMIT_EXCEEDED', 429);
-  }
-}
-
-/**
- * 500 - Internal Server Error
- * Use for unexpected server errors
- */
-export class InternalServerError extends AppError {
-  constructor(message = 'Internal server error') {
-    super(message, 'INTERNAL_SERVER_ERROR', 500);
-  }
-}
-
-/**
- * 503 - Service Unavailable
- * Use when service is temporarily unavailable
- */
-export class ServiceUnavailableError extends AppError {
-  constructor(message = 'Service temporarily unavailable') {
-    super(message, 'SERVICE_UNAVAILABLE', 503);
-  }
-}
+export type { ErrorCode } from './codes';
+export { ErrorCodes } from './codes';
+export { isHttpError } from './guards';
+export type { HttpErrorOptions } from './http-error';
+export {
+  ConflictError,
+  ForbiddenError,
+  HttpError,
+  InternalServerError,
+  NotFoundError,
+  RateLimitError,
+  ServiceUnavailableError,
+  UnauthorizedError,
+  ValidationError,
+} from './http-error';

--- a/packages/ui/src/default-catch-boundary.tsx
+++ b/packages/ui/src/default-catch-boundary.tsx
@@ -1,15 +1,7 @@
-import { AppError } from '@xbrk/errors';
+import { isHttpError } from '@xbrk/errors';
 import { AlertTriangle } from 'lucide-react';
 import { Button } from './button';
 import { Separator } from './separator';
-
-// Type guard to check if error is AppError
-function isAppError(error: unknown): error is AppError {
-  return (
-    error instanceof AppError ||
-    (error !== null && typeof error === 'object' && 'code' in error && 'statusCode' in error && 'message' in error)
-  );
-}
 
 interface DefaultCatchBoundaryProps {
   debug?: boolean;
@@ -18,10 +10,9 @@ interface DefaultCatchBoundaryProps {
 }
 
 export function DefaultCatchBoundary({ error, reset, debug = false }: DefaultCatchBoundaryProps) {
-  // Check if it's a known error type using type guard
-  const errorCode = isAppError(error) ? error.code : 'UNKNOWN_ERROR';
-  const statusCode = isAppError(error) ? error.statusCode : 500;
-  const metadata = isAppError(error) ? error.metadata : undefined;
+  const errorCode = isHttpError(error) ? error.code : 'UNKNOWN_ERROR';
+  const statusCode = isHttpError(error) ? error.statusCode : 500;
+  const metadata = isHttpError(error) ? error.metadata : undefined;
 
   const handleRetry = () => {
     if (reset) {


### PR DESCRIPTION
## Summary

Migrates `packages/errors` from a single-file `AppError` base class to a modular, typed error system. Every `throw new Error(...)` in `packages/api` services has been replaced with domain-appropriate typed errors, eliminating brittle string-matching in catch blocks.

## Changes

### `packages/errors` — refactored

| File | Description |
|------|-------------|
| `src/codes.ts` | `ErrorCodes` const object + `ErrorCode` string union type |
| `src/http-error.ts` | `HttpError` replaces `AppError` + all 7 subclass errors |
| `src/guards.ts` | `isHttpError` type guard (replaces inlined version in `packages/ui`) |
| `src/index.ts` | Barrel re-exports from new modules |

Key API improvements:
- **Constructor consistency**: all errors use `(message, options?)` where `options` accepts `cause` and `metadata`
- **`NotFoundError.forResource(resource)`**: static factory for the `"X not found"` pattern
- **Typed `.code`**: `ErrorCode` union instead of plain `string` for autocomplete and exhaustiveness
- **`toJSON(includeStack?)`**: optionally includes stack trace for debugging
- **`isHttpError` guard**: exported from the package instead of duplicated per-consumer

### `packages/api` — ~30 `throw new Error` → typed errors

| Error Type | Domain | Occurrences |
|------------|--------|-------------|
| `NotFoundError` | Entity not found, non-public draft content | 17 |
| `ForbiddenError` | Unauthorized delete operations | 2 |
| `ValidationError` | Invalid image, URL, search query, stats params | 5 |
| `InternalServerError` | Catch->rethrow after DB / storage failure | 6 |

All catch blocks that previously checked `error.message === 'X'` or `.includes('Y')` now use `instanceof` checks against typed errors.

### Consumer fixes

- `packages/ui`: removed inlined `isAppError` guard, uses `isHttpError` from package
- `apps/web` + `apps/dashboard`: fixed `ValidationError` call sites that passed `details` as a positional key instead of `{ metadata: { details } }`

## Verification

- `pnpm typecheck` — 12/12 tasks pass
- Pre-commit hooks (ultracite/oxlint) pass clean
- All existing error behavior preserved: status codes, message defaults, serialization shape remain identical

## Migration path

Consumers importing `AppError` need to migrate to `HttpError`. No other breaking changes — all named error classes (`ValidationError`, `NotFoundError`, etc.) keep the same export names and behavior.
