### PR TITLE
refactor(ui): extract cn utility, fix bugs, remove tooltip auto-provider

### DIFF
--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { createRootRouteWithContext, HeadContent, Scripts } from '@tanstack/reac
 import { siteConfig } from '@xbrk/config';
 import { Toaster } from '@xbrk/ui/sonner';
 import { ThemeProvider, useTheme } from '@xbrk/ui/theme-provider';
+import { TooltipProvider } from '@xbrk/ui/tooltip';
 import { DevtoolsComponent } from '@/components/dev-tools';
 import { type AuthQueryResult, authQueryOptions } from '@/lib/auth/queries';
 import appCss from '@/styles.css?url';
@@ -58,11 +59,13 @@ function ShellComponent({ children }: { readonly children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">
-        {children}
-        <Toaster resolvedTheme={resolvedTheme} />
+        <TooltipProvider>
+          {children}
+          <Toaster resolvedTheme={resolvedTheme} />
 
-        {import.meta.env.DEV && <DevtoolsComponent />}
-        <Scripts />
+          {import.meta.env.DEV && <DevtoolsComponent />}
+          <Scripts />
+        </TooltipProvider>
       </body>
     </html>
   );

--- a/apps/web/src/components/about/experience-entry.tsx
+++ b/apps/web/src/components/about/experience-entry.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '@xbrk/ui/badge';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@xbrk/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@xbrk/ui/tooltip';
 import { BriefcaseIcon, CalendarIcon, MapPinIcon } from 'lucide-react';
 
 import Link from '@/components/shared/link';
@@ -92,30 +92,28 @@ const ExperienceEntry = ({ experience }: ExperienceEntryProps): React.ReactNode 
       </div>
 
       {techStacks.length > 0 && (
-        <TooltipProvider>
-          <div className="my-2 flex flex-row flex-wrap gap-1.5">
-            {techStacks.map((tech) => (
-              <Tooltip key={tech.name}>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center justify-center rounded-lg border border-border p-2 transition-colors hover:bg-secondary">
-                    <svg
-                      className="h-4 w-4"
-                      fill="currentColor"
-                      role="img"
-                      style={{ color: tech.color }}
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <title>{tech.icon.title}</title>
-                      <path d={tech.icon.path} />
-                    </svg>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>{tech.name}</TooltipContent>
-              </Tooltip>
-            ))}
-          </div>
-        </TooltipProvider>
+        <div className="my-2 flex flex-row flex-wrap gap-1.5">
+          {techStacks.map((tech) => (
+            <Tooltip key={tech.name}>
+              <TooltipTrigger asChild>
+                <div className="flex items-center justify-center rounded-lg border border-border p-2 transition-colors hover:bg-secondary">
+                  <svg
+                    className="h-4 w-4"
+                    fill="currentColor"
+                    role="img"
+                    style={{ color: tech.color }}
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <title>{tech.icon.title}</title>
+                    <path d={tech.icon.path} />
+                  </svg>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>{tech.name}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
       )}
 
       <TimelineEntryAccomplishments accomplishments={accomplishments} />

--- a/apps/web/src/components/about/experience-entry.tsx
+++ b/apps/web/src/components/about/experience-entry.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '@xbrk/ui/badge';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@xbrk/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@xbrk/ui/tooltip';
 import { BriefcaseIcon, CalendarIcon, MapPinIcon } from 'lucide-react';
 
 import Link from '@/components/shared/link';
@@ -92,28 +92,30 @@ const ExperienceEntry = ({ experience }: ExperienceEntryProps): React.ReactNode 
       </div>
 
       {techStacks.length > 0 && (
-        <div className="my-2 flex flex-row flex-wrap gap-1.5">
-          {techStacks.map((tech) => (
-            <Tooltip key={tech.name}>
-              <TooltipTrigger asChild>
-                <div className="flex items-center justify-center rounded-lg border border-border p-2 transition-colors hover:bg-secondary">
-                  <svg
-                    className="h-4 w-4"
-                    fill="currentColor"
-                    role="img"
-                    style={{ color: tech.color }}
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <title>{tech.icon.title}</title>
-                    <path d={tech.icon.path} />
-                  </svg>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>{tech.name}</TooltipContent>
-            </Tooltip>
-          ))}
-        </div>
+        <TooltipProvider>
+          <div className="my-2 flex flex-row flex-wrap gap-1.5">
+            {techStacks.map((tech) => (
+              <Tooltip key={tech.name}>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center justify-center rounded-lg border border-border p-2 transition-colors hover:bg-secondary">
+                    <svg
+                      className="h-4 w-4"
+                      fill="currentColor"
+                      role="img"
+                      style={{ color: tech.color }}
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <title>{tech.icon.title}</title>
+                      <path d={tech.icon.path} />
+                    </svg>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{tech.name}</TooltipContent>
+              </Tooltip>
+            ))}
+          </div>
+        </TooltipProvider>
       )}
 
       <TimelineEntryAccomplishments accomplishments={accomplishments} />

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { ClientOnly, createRootRouteWithContext, HeadContent, Scripts } from '@t
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { Toaster } from '@xbrk/ui/sonner';
 import { ThemeProvider, useTheme } from '@xbrk/ui/theme-provider';
+import { TooltipProvider } from '@xbrk/ui/tooltip';
 import posthog from 'posthog-js';
 import { CookieBanner } from '@/components/analytics/cookie-banner';
 import { DevtoolsComponent } from '@/components/dev-tools';
@@ -170,21 +171,23 @@ function ShellComponent({ children }: { children: React.ReactNode }) {
 
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">
         <PostHogProvider client={posthog}>
-          <MotionProvider>
-            <RouteProgress />
+          <TooltipProvider>
+            <MotionProvider>
+              <RouteProgress />
 
-            {children}
+              {children}
 
-            <Toaster resolvedTheme={resolvedTheme} />
+              <Toaster resolvedTheme={resolvedTheme} />
 
-            {import.meta.env.DEV && <DevtoolsComponent />}
+              {import.meta.env.DEV && <DevtoolsComponent />}
 
-            <ClientOnly>
-              <CookieBanner />
-            </ClientOnly>
+              <ClientOnly>
+                <CookieBanner />
+              </ClientOnly>
 
-            <Scripts />
-          </MotionProvider>
+              <Scripts />
+            </MotionProvider>
+          </TooltipProvider>
         </PostHogProvider>
       </body>
     </html>

--- a/packages/ui/src/alert-dialog.tsx
+++ b/packages/ui/src/alert-dialog.tsx
@@ -9,9 +9,9 @@ import {
   Title,
   Trigger,
 } from '@radix-ui/react-alert-dialog';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
 import { buttonVariants } from './button';
+import { cn } from './lib/cn';
 
 function AlertDialog({ ...props }: Readonly<ComponentProps<typeof Root>>) {
   return <Root data-slot="alert-dialog" {...props} />;

--- a/packages/ui/src/avatar.tsx
+++ b/packages/ui/src/avatar.tsx
@@ -1,6 +1,6 @@
 import { Fallback, Image, Root } from '@radix-ui/react-avatar';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Avatar({ className, ...props }: ComponentProps<typeof Root>) {
   return (

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
-import { cn } from '@xbrk/ui';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 const badgeVariants = cva(
   'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border px-2 py-0.5 font-medium text-xs transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',

--- a/packages/ui/src/breadcrumb.tsx
+++ b/packages/ui/src/breadcrumb.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
-import { cn } from '@xbrk/ui';
 import { ChevronRight, MoreHorizontal } from 'lucide-react';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Breadcrumb({ ...props }: ComponentProps<'nav'>) {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
-import { cn } from '@xbrk/ui';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 select-none items-center justify-center whitespace-nowrap rounded-lg border border-transparent bg-clip-padding font-medium text-sm outline-none transition-all focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",

--- a/packages/ui/src/calendar.tsx
+++ b/packages/ui/src/calendar.tsx
@@ -1,8 +1,43 @@
-import { cn } from '@xbrk/ui';
 import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import { type ComponentProps, useEffect, useRef } from 'react';
 import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker';
 import { Button, buttonVariants } from './button';
+import { cn } from './lib/cn';
+
+function CalendarRoot({
+  className,
+  rootRef,
+  ...props
+}: ComponentProps<'div'> & { rootRef?: React.Ref<HTMLDivElement> }) {
+  return <div className={cn(className)} data-slot="calendar" ref={rootRef} {...props} />;
+}
+
+function CalendarChevron({
+  className,
+  orientation,
+  ...props
+}: {
+  className?: string;
+  orientation?: 'left' | 'right' | 'up' | 'down';
+}) {
+  if (orientation === 'left') {
+    return <ChevronLeftIcon className={cn('size-4', className)} {...props} />;
+  }
+
+  if (orientation === 'right') {
+    return <ChevronRightIcon className={cn('size-4', className)} {...props} />;
+  }
+
+  return <ChevronDownIcon className={cn('size-4', className)} {...props} />;
+}
+
+function CalendarWeekNumber({ children, ...props }: ComponentProps<'td'>) {
+  return (
+    <td {...props}>
+      <div className="flex size-(--cell-size) items-center justify-center text-center">{children}</div>
+    </td>
+  );
+}
 
 function Calendar({
   className,
@@ -91,29 +126,10 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: valid component
-        Root: ({ className, rootRef, ...props }) => (
-          <div className={cn(className)} data-slot="calendar" ref={rootRef} {...props} />
-        ),
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: valid component
-        Chevron: ({ className, orientation, ...props }) => {
-          if (orientation === 'left') {
-            return <ChevronLeftIcon className={cn('size-4', className)} {...props} />;
-          }
-
-          if (orientation === 'right') {
-            return <ChevronRightIcon className={cn('size-4', className)} {...props} />;
-          }
-
-          return <ChevronDownIcon className={cn('size-4', className)} {...props} />;
-        },
+        Root: CalendarRoot,
+        Chevron: CalendarChevron,
         DayButton: CalendarDayButton,
-        // biome-ignore lint/correctness/noNestedComponentDefinitions: valid component
-        WeekNumber: ({ children, ...props }) => (
-          <td {...props}>
-            <div className="flex size-(--cell-size) items-center justify-center text-center">{children}</div>
-          </td>
-        ),
+        WeekNumber: CalendarWeekNumber,
         ...components,
       }}
       formatters={{

--- a/packages/ui/src/callout.tsx
+++ b/packages/ui/src/callout.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@xbrk/ui';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info, Skull } from 'lucide-react';
+import { cn } from './lib/cn';
 
 const calloutVariants = {
   default: {

--- a/packages/ui/src/card.tsx
+++ b/packages/ui/src/card.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Card({ className, ...props }: ComponentProps<'div'>) {
   return (

--- a/packages/ui/src/carousel.tsx
+++ b/packages/ui/src/carousel.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@xbrk/ui';
 import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
 import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { type ComponentProps, createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { Button } from './button';
+import { cn } from './lib/cn';
 
 type CarouselApi = UseEmblaCarouselType[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;

--- a/packages/ui/src/chart.tsx
+++ b/packages/ui/src/chart.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@xbrk/ui';
 import { type ComponentProps, createContext, useContext, useId, useMemo } from 'react';
 import {
   type DefaultLegendContentProps,
@@ -8,6 +7,7 @@ import {
   Tooltip,
 } from 'recharts';
 import type { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
+import { cn } from './lib/cn';
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: '', dark: '.dark' } as const;

--- a/packages/ui/src/checkbox.tsx
+++ b/packages/ui/src/checkbox.tsx
@@ -1,7 +1,7 @@
 import { Indicator, Root } from '@radix-ui/react-checkbox';
-import { cn } from '@xbrk/ui';
 import { CheckIcon } from 'lucide-react';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Checkbox({ className, ...props }: ComponentProps<typeof Root>) {
   return (

--- a/packages/ui/src/code-block-header.tsx
+++ b/packages/ui/src/code-block-header.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@xbrk/ui';
 import { FileCode, FileText, FolderOpen, TerminalIcon } from 'lucide-react';
 import type { HTMLAttributes, ReactNode } from 'react';
 import {
@@ -14,6 +13,7 @@ import {
   siVercel,
 } from 'simple-icons';
 import Icon from './icon';
+import { cn } from './lib/cn';
 
 type CodeBlockProps = HTMLAttributes<HTMLElement> & {
   title?: string;

--- a/packages/ui/src/code-block.tsx
+++ b/packages/ui/src/code-block.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@xbrk/ui';
-import { type ComponentProps, useEffect, useRef, useState } from 'react';
+import { type ComponentProps, useCallback, useEffect, useRef, useState } from 'react';
 import CopyButton from './copy-button';
 import { getIconByLanguage } from './icon';
+import { cn } from './lib/cn';
 import { ScrollArea, ScrollBar } from './scroll-area';
 
 type CodeBlockProps = {
@@ -24,6 +24,18 @@ export default function CodeBlock({
   const Icon = getIconByLanguage(lang ?? '');
   const textInput = useRef<HTMLPreElement>(null);
   const [copyText, setCopyText] = useState('');
+
+  const preRef = useCallback(
+    (node: HTMLPreElement | null) => {
+      textInput.current = node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    },
+    [ref],
+  );
 
   useEffect(() => {
     if (textInput.current) {
@@ -52,7 +64,7 @@ export default function CodeBlock({
       )}
 
       <ScrollArea>
-        <pre className={cn('!bg-transparent p-4 text-[13px]', className)} ref={textInput} {...rest}>
+        <pre className={cn('!bg-transparent p-4 text-[13px]', className)} ref={preRef} {...rest}>
           {children}
         </pre>
         <ScrollBar orientation="horizontal" />

--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@xbrk/ui';
 import { Command as CommandPrimitive } from 'cmdk';
 import { SearchIcon } from 'lucide-react';
 import { type ComponentProps } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './dialog';
+import { cn } from './lib/cn';
 
 function Command({ className, ...props }: ComponentProps<typeof CommandPrimitive>) {
   return (

--- a/packages/ui/src/component-preview.tsx
+++ b/packages/ui/src/component-preview.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@xbrk/ui';
+import { cn } from './lib/cn';
 
 type ComponentPreviewProps = React.HTMLAttributes<HTMLDivElement>;
 

--- a/packages/ui/src/copy-button.tsx
+++ b/packages/ui/src/copy-button.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@xbrk/ui';
 import { Check, Copy } from 'lucide-react';
 import type { HTMLAttributes } from 'react';
 import { useCopyToClipboard } from 'react-use';
 import { Button } from './button';
+import { cn } from './lib/cn';
 
 interface CopyButtonProps extends HTMLAttributes<HTMLButtonElement> {
   value: string;

--- a/packages/ui/src/default-catch-boundary.tsx
+++ b/packages/ui/src/default-catch-boundary.tsx
@@ -1,6 +1,7 @@
 import { isHttpError } from '@xbrk/errors';
 import { AlertTriangle } from 'lucide-react';
 import { Button } from './button';
+import { GLITCH_STYLES } from './internal/glitch-styles';
 import { Separator } from './separator';
 
 interface DefaultCatchBoundaryProps {
@@ -24,61 +25,7 @@ export function DefaultCatchBoundary({ error, reset, debug = false }: DefaultCat
 
   return (
     <>
-      {/* Glitch styles */}
-      <style>
-        {`
-          @keyframes glitch {
-            0%, 100% { transform: translate(0); }
-            20% { transform: translate(-2px, 2px); }
-            40% { transform: translate(-2px, -2px); }
-            60% { transform: translate(2px, 2px); }
-            80% { transform: translate(2px, -2px); }
-          }
-          
-          @keyframes glitch-top {
-            0%, 100% { clip-path: polygon(0% 0%, 100% 0%, 100% 33%, 0% 33%); transform: translate(0); }
-            20% { clip-path: polygon(0% 0%, 100% 0%, 100% 30%, 0% 30%); transform: translate(-3px, 0); }
-            40% { clip-path: polygon(0% 0%, 100% 0%, 100% 35%, 0% 35%); transform: translate(3px, 0); }
-            60% { clip-path: polygon(0% 0%, 100% 0%, 100% 28%, 0% 28%); transform: translate(-2px, 0); }
-            80% { clip-path: polygon(0% 0%, 100% 0%, 100% 32%, 0% 32%); transform: translate(2px, 0); }
-          }
-          
-          @keyframes glitch-bottom {
-            0%, 100% { clip-path: polygon(0% 67%, 100% 67%, 100% 100%, 0% 100%); transform: translate(0); }
-            20% { clip-path: polygon(0% 70%, 100% 70%, 100% 100%, 0% 100%); transform: translate(3px, 0); }
-            40% { clip-path: polygon(0% 65%, 100% 65%, 100% 100%, 0% 100%); transform: translate(-3px, 0); }
-            60% { clip-path: polygon(0% 72%, 100% 72%, 100% 100%, 0% 100%); transform: translate(2px, 0); }
-            80% { clip-path: polygon(0% 68%, 100% 68%, 100% 100%, 0% 100%); transform: translate(-2px, 0); }
-          }
-          
-          .glitch-container {
-            position: relative;
-            animation: glitch 2.0s infinite;
-          }
-          
-          .glitch-container::before,
-          .glitch-container::after {
-            content: attr(data-text);
-            position: absolute;
-            left: 0;
-            top: 0;
-            width: 100%;
-            height: 100%;
-          }
-          
-          .glitch-container::before {
-            animation: glitch-top 0.4s infinite;
-            color: #ff00ff;
-            z-index: -1;
-          }
-          
-          .glitch-container::after {
-            animation: glitch-bottom 0.4s infinite;
-            color: #00ffff;
-            z-index: -2;
-          }
-        `}
-      </style>
+      <style>{GLITCH_STYLES}</style>
 
       <div className="flex min-h-[60vh] flex-col items-center justify-center space-y-6 px-4">
         {/* Glitch animation */}

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -1,7 +1,7 @@
 import { Close, Content, Description, Overlay, Portal, Root, Title, Trigger } from '@radix-ui/react-dialog';
-import { cn } from '@xbrk/ui';
 import { XIcon } from 'lucide-react';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Dialog({ ...props }: Readonly<ComponentProps<typeof Root>>) {
   return <Root data-slot="dialog" {...props} />;

--- a/packages/ui/src/dropdown-menu.tsx
+++ b/packages/ui/src/dropdown-menu.tsx
@@ -15,9 +15,9 @@ import {
   SubTrigger,
   Trigger,
 } from '@radix-ui/react-dropdown-menu';
-import { cn } from '@xbrk/ui';
 import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function DropdownMenu({ ...props }: Readonly<ComponentProps<typeof Root>>) {
   return <Root data-slot="dropdown-menu" {...props} />;

--- a/packages/ui/src/field.tsx
+++ b/packages/ui/src/field.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@xbrk/ui';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { useMemo } from 'react';
 import { Label } from './label';
+import { cn } from './lib/cn';
 import { Separator } from './separator';
 
 function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {

--- a/packages/ui/src/files.tsx
+++ b/packages/ui/src/files.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@xbrk/ui';
 import { cva } from 'class-variance-authority';
 import { FileIcon, FolderIcon, FolderOpenIcon } from 'lucide-react';
 import { useState } from 'react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './collapsible';
+import { cn } from './lib/cn';
 
 type FilesProps = React.ComponentPropsWithoutRef<'div'>;
 type FileProps = {
@@ -32,7 +32,7 @@ export const File = (props: FileProps) => {
   const { name, className, ...rest } = props;
 
   return (
-    <div className={cn(item({ className }))} {...rest}>
+    <div className={cn(item(), className)} {...rest}>
       <FileIcon className="size-4" />
       {name}
     </div>

--- a/packages/ui/src/folder-tree.tsx
+++ b/packages/ui/src/folder-tree.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@xbrk/ui';
 import { FileCode, Folder } from 'lucide-react';
 import { Fragment } from 'react';
+import { cn } from './lib/cn';
 
 interface Node {
   children?: Node[];

--- a/packages/ui/src/form.tsx
+++ b/packages/ui/src/form.tsx
@@ -1,8 +1,8 @@
 import { Slot } from '@radix-ui/react-slot';
 import { createFormHook, createFormHookContexts, useStore } from '@tanstack/react-form';
-import { cn } from '@xbrk/ui';
 import { createContext, useContext, useId } from 'react';
 import { Label } from './label';
+import { cn } from './lib/cn';
 
 const { fieldContext, formContext, useFieldContext: useFormFieldContext, useFormContext } = createFormHookContexts();
 

--- a/packages/ui/src/hover-card.tsx
+++ b/packages/ui/src/hover-card.tsx
@@ -1,6 +1,6 @@
 import { Content, Portal, Root, Trigger } from '@radix-ui/react-hover-card';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function HoverCard({ ...props }: Readonly<ComponentProps<typeof Root>>) {
   return <Root data-slot="hover-card" {...props} />;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,1 @@
-import { cx } from 'class-variance-authority';
-import { twMerge } from 'tailwind-merge';
-
-export const cn = (...inputs: Parameters<typeof cx>) => twMerge(cx(inputs));
+export { cn } from './lib/cn';

--- a/packages/ui/src/input.tsx
+++ b/packages/ui/src/input.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Input({ className, type, ...props }: ComponentProps<'input'>) {
   return (

--- a/packages/ui/src/internal/glitch-styles.ts
+++ b/packages/ui/src/internal/glitch-styles.ts
@@ -1,0 +1,52 @@
+export const GLITCH_STYLES = `
+@keyframes glitch {
+  0%, 100% { transform: translate(0); }
+  20% { transform: translate(-2px, 2px); }
+  40% { transform: translate(-2px, -2px); }
+  60% { transform: translate(2px, 2px); }
+  80% { transform: translate(2px, -2px); }
+}
+
+@keyframes glitch-top {
+  0%, 100% { clip-path: polygon(0% 0%, 100% 0%, 100% 33%, 0% 33%); transform: translate(0); }
+  20% { clip-path: polygon(0% 0%, 100% 0%, 100% 30%, 0% 30%); transform: translate(-3px, 0); }
+  40% { clip-path: polygon(0% 0%, 100% 0%, 100% 35%, 0% 35%); transform: translate(3px, 0); }
+  60% { clip-path: polygon(0% 0%, 100% 0%, 100% 28%, 0% 28%); transform: translate(-2px, 0); }
+  80% { clip-path: polygon(0% 0%, 100% 0%, 100% 32%, 0% 32%); transform: translate(2px, 0); }
+}
+
+@keyframes glitch-bottom {
+  0%, 100% { clip-path: polygon(0% 67%, 100% 67%, 100% 100%, 0% 100%); transform: translate(0); }
+  20% { clip-path: polygon(0% 70%, 100% 70%, 100% 100%, 0% 100%); transform: translate(3px, 0); }
+  40% { clip-path: polygon(0% 65%, 100% 65%, 100% 100%, 0% 100%); transform: translate(-3px, 0); }
+  60% { clip-path: polygon(0% 72%, 100% 72%, 100% 100%, 0% 100%); transform: translate(2px, 0); }
+  80% { clip-path: polygon(0% 68%, 100% 68%, 100% 100%, 0% 100%); transform: translate(-2px, 0); }
+}
+
+.glitch-container {
+  position: relative;
+  animation: glitch 2.0s infinite;
+}
+
+.glitch-container::before,
+.glitch-container::after {
+  content: attr(data-text);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.glitch-container::before {
+  animation: glitch-top 0.4s infinite;
+  color: #ff00ff;
+  z-index: -1;
+}
+
+.glitch-container::after {
+  animation: glitch-bottom 0.4s infinite;
+  color: #00ffff;
+  z-index: -2;
+}
+`;

--- a/packages/ui/src/label.tsx
+++ b/packages/ui/src/label.tsx
@@ -1,6 +1,6 @@
 import { Root } from '@radix-ui/react-label';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Label({ className, ...props }: Readonly<ComponentProps<typeof Root>>) {
   return (

--- a/packages/ui/src/lazy-image.tsx
+++ b/packages/ui/src/lazy-image.tsx
@@ -1,8 +1,8 @@
 import { Image } from '@unpic/react';
-import { cn } from '@xbrk/ui';
 import type { HTMLAttributes } from 'react';
 import { useCallback, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { cn } from './lib/cn';
 
 type LazyImageProps = HTMLAttributes<HTMLDivElement> & {
   src: string;

--- a/packages/ui/src/lib/cn.ts
+++ b/packages/ui/src/lib/cn.ts
@@ -1,0 +1,4 @@
+import { cx } from 'class-variance-authority';
+import { twMerge } from 'tailwind-merge';
+
+export const cn = (...inputs: Parameters<typeof cx>) => twMerge(cx(inputs));

--- a/packages/ui/src/loading-skeleton.tsx
+++ b/packages/ui/src/loading-skeleton.tsx
@@ -1,12 +1,15 @@
 export default function LoadingSkeleton() {
   return (
-    <div className="relative isolate space-y-5 overflow-hidden rounded-2xl bg-white/5 p-4 shadow-black/5 shadow-xl before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:border-gray-600/10 before:border-t before:bg-gradient-to-r before:from-transparent before:via-gray-600/10 before:to-transparent dark:before:border-rose-100/10 dark:before:via-rose-100/10">
-      <div className="h-24 rounded-lg bg-gray-200/80 dark:bg-rose-100/10" />
-      <div className="space-y-3">
-        <div className="h-3 w-3/5 rounded-lg bg-gray-200/80 dark:bg-rose-100/10" />
-        <div className="h-3 w-4/5 rounded-lg bg-gray-200/70 dark:bg-rose-100/20" />
-        <div className="h-3 w-2/5 rounded-lg bg-gray-200/70 dark:bg-rose-100/20" />
+    <>
+      <style>{'@keyframes shimmer { 100% { transform: translateX(100%); } }'}</style>
+      <div className="relative isolate space-y-5 overflow-hidden rounded-2xl bg-white/5 p-4 shadow-black/5 shadow-xl before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:border-gray-600/10 before:border-t before:bg-gradient-to-r before:from-transparent before:via-gray-600/10 before:to-transparent dark:before:border-rose-100/10 dark:before:via-rose-100/10">
+        <div className="h-24 rounded-lg bg-gray-200/80 dark:bg-rose-100/10" />
+        <div className="space-y-3">
+          <div className="h-3 w-3/5 rounded-lg bg-gray-200/80 dark:bg-rose-100/10" />
+          <div className="h-3 w-4/5 rounded-lg bg-gray-200/70 dark:bg-rose-100/20" />
+          <div className="h-3 w-2/5 rounded-lg bg-gray-200/70 dark:bg-rose-100/20" />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/ui/src/multi-select.tsx
+++ b/packages/ui/src/multi-select.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@xbrk/ui';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { CheckIcon, ChevronDown, WandSparkles, X, XCircle } from 'lucide-react';
 import { type ComponentProps, useState } from 'react';
@@ -13,6 +12,7 @@ import {
   CommandList,
   CommandSeparator,
 } from './command';
+import { cn } from './lib/cn';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 import { Separator } from './separator';
 

--- a/packages/ui/src/navigation-menu.tsx
+++ b/packages/ui/src/navigation-menu.tsx
@@ -1,8 +1,8 @@
 import { Content, Indicator, Item, Link, List, Root, Trigger, Viewport } from '@radix-ui/react-navigation-menu';
-import { cn } from '@xbrk/ui';
 import { cva } from 'class-variance-authority';
 import { ChevronDownIcon } from 'lucide-react';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function NavigationMenu({
   className,

--- a/packages/ui/src/not-found.tsx
+++ b/packages/ui/src/not-found.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { GLITCH_STYLES } from './internal/glitch-styles';
 
 export function NotFound(
   props: Readonly<{
@@ -7,60 +8,7 @@ export function NotFound(
 ) {
   return (
     <>
-      <style>
-        {`
-          @keyframes glitch {
-            0%, 100% { transform: translate(0); }
-            20% { transform: translate(-2px, 2px); }
-            40% { transform: translate(-2px, -2px); }
-            60% { transform: translate(2px, 2px); }
-            80% { transform: translate(2px, -2px); }
-          }
-          
-          @keyframes glitch-top {
-            0%, 100% { clip-path: polygon(0% 0%, 100% 0%, 100% 33%, 0% 33%); transform: translate(0); }
-            20% { clip-path: polygon(0% 0%, 100% 0%, 100% 30%, 0% 30%); transform: translate(-3px, 0); }
-            40% { clip-path: polygon(0% 0%, 100% 0%, 100% 35%, 0% 35%); transform: translate(3px, 0); }
-            60% { clip-path: polygon(0% 0%, 100% 0%, 100% 28%, 0% 28%); transform: translate(-2px, 0); }
-            80% { clip-path: polygon(0% 0%, 100% 0%, 100% 32%, 0% 32%); transform: translate(2px, 0); }
-          }
-          
-          @keyframes glitch-bottom {
-            0%, 100% { clip-path: polygon(0% 67%, 100% 67%, 100% 100%, 0% 100%); transform: translate(0); }
-            20% { clip-path: polygon(0% 70%, 100% 70%, 100% 100%, 0% 100%); transform: translate(3px, 0); }
-            40% { clip-path: polygon(0% 65%, 100% 65%, 100% 100%, 0% 100%); transform: translate(-3px, 0); }
-            60% { clip-path: polygon(0% 72%, 100% 72%, 100% 100%, 0% 100%); transform: translate(2px, 0); }
-            80% { clip-path: polygon(0% 68%, 100% 68%, 100% 100%, 0% 100%); transform: translate(-2px, 0); }
-          }
-          
-          .glitch-container {
-            position: relative;
-            animation: glitch 2.0s infinite;
-          }
-          
-          .glitch-container::before,
-          .glitch-container::after {
-            content: attr(data-text);
-            position: absolute;
-            left: 0;
-            top: 0;
-            width: 100%;
-            height: 100%;
-          }
-          
-          .glitch-container::before {
-            animation: glitch-top 0.4s infinite;
-            color: #ff00ff;
-            z-index: -1;
-          }
-          
-          .glitch-container::after {
-            animation: glitch-bottom 0.4s infinite;
-            color: #00ffff;
-            z-index: -2;
-          }
-        `}
-      </style>
+      <style>{GLITCH_STYLES}</style>
       <div className="flex min-h-[60vh] flex-col items-center justify-center">
         <h1
           className="glitch-container mb-6 font-black text-7xl leading-tight tracking-tight sm:text-9xl"

--- a/packages/ui/src/popover.tsx
+++ b/packages/ui/src/popover.tsx
@@ -1,6 +1,6 @@
 import { Anchor, Content, Portal, Root, Trigger } from '@radix-ui/react-popover';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Popover({ ...props }: Readonly<ComponentProps<typeof Root>>) {
   return <Root data-slot="popover" {...props} />;

--- a/packages/ui/src/progress.tsx
+++ b/packages/ui/src/progress.tsx
@@ -1,6 +1,6 @@
 import { Indicator, Root } from '@radix-ui/react-progress';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Progress({ className, value, ...props }: Readonly<ComponentProps<typeof Root>>) {
   return (

--- a/packages/ui/src/scroll-area.tsx
+++ b/packages/ui/src/scroll-area.tsx
@@ -1,6 +1,6 @@
 import { Corner, Root, ScrollAreaScrollbar, ScrollAreaThumb, Viewport } from '@radix-ui/react-scroll-area';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function ScrollArea({ className, children, ...props }: ComponentProps<typeof Root>) {
   return (

--- a/packages/ui/src/select.tsx
+++ b/packages/ui/src/select.tsx
@@ -15,9 +15,9 @@ import {
   Value,
   Viewport,
 } from '@radix-ui/react-select';
-import { cn } from '@xbrk/ui';
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Select({ ...props }: Readonly<ComponentProps<typeof Root>>) {
   return <Root data-slot="select" {...props} />;

--- a/packages/ui/src/separator.tsx
+++ b/packages/ui/src/separator.tsx
@@ -1,6 +1,6 @@
 import { Root } from '@radix-ui/react-separator';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Separator({
   className,

--- a/packages/ui/src/sheet.tsx
+++ b/packages/ui/src/sheet.tsx
@@ -1,7 +1,7 @@
 import { Close, Content, Description, Overlay, Portal, Root, Title, Trigger } from '@radix-ui/react-dialog';
-import { cn } from '@xbrk/ui';
 import { XIcon } from 'lucide-react';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Sheet({ ...props }: ComponentProps<typeof Root>) {
   return <Root data-slot="sheet" {...props} />;

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -1,5 +1,4 @@
 import { Slot } from '@radix-ui/react-slot';
-import { cn } from '@xbrk/ui';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
 import {
@@ -15,6 +14,7 @@ import {
 import { Button } from './button';
 import { useIsMobile } from './hooks/use-mobile';
 import { Input } from './input';
+import { cn } from './lib/cn';
 import { Separator } from './separator';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from './sheet';
 import { Skeleton } from './skeleton';
@@ -565,12 +565,13 @@ function SidebarMenuBadge({ className, ...props }: ComponentProps<'div'>) {
 function SidebarMenuSkeleton({
   className,
   showIcon = false,
+  width: widthProp,
   ...props
 }: ComponentProps<'div'> & {
   showIcon?: boolean;
+  width?: string;
 }) {
-  // Random width between 50 to 90%.
-  const width = useMemo(() => `${Math.floor(Math.random() * 40) + 50}%`, []);
+  const width = widthProp ?? '80%';
 
   return (
     <div

--- a/packages/ui/src/sign-in-button.tsx
+++ b/packages/ui/src/sign-in-button.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
 import type { SimpleIcon } from 'simple-icons';
 import { Button } from './button';
 import Icon from './icon';
+import { cn } from './lib/cn';
 
 interface SignInButtonProps extends ComponentProps<typeof Button> {
   icon: SimpleIcon;

--- a/packages/ui/src/skeleton.tsx
+++ b/packages/ui/src/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@xbrk/ui';
+import { cn } from './lib/cn';
 
 function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return <div className={cn('animate-pulse rounded-md bg-accent', className)} data-slot="skeleton" {...props} />;

--- a/packages/ui/src/spinner.tsx
+++ b/packages/ui/src/spinner.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@xbrk/ui';
 import { Loader2Icon } from 'lucide-react';
+import { cn } from './lib/cn';
 
 function Spinner({ className, ...props }: React.ComponentProps<'svg'>) {
   return <Loader2Icon aria-label="Loading" className={cn('size-4 animate-spin', className)} role="status" {...props} />;

--- a/packages/ui/src/table.tsx
+++ b/packages/ui/src/table.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 const Table = ({ className, ...props }: ComponentProps<'table'>) => (
   <div className="relative w-full overflow-x-auto" data-slot="table-container">

--- a/packages/ui/src/tabs.tsx
+++ b/packages/ui/src/tabs.tsx
@@ -1,6 +1,6 @@
 import { Content, List, Root, Trigger } from '@radix-ui/react-tabs';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Tabs({ className, ...props }: Readonly<ComponentProps<typeof Root>>) {
   return <Root className={cn('flex flex-col gap-2', className)} data-slot="tabs" {...props} />;

--- a/packages/ui/src/tag-list.tsx
+++ b/packages/ui/src/tag-list.tsx
@@ -1,4 +1,5 @@
 import { Badge } from './badge';
+import { cn } from './lib/cn';
 
 interface TagListProps {
   className?: string;
@@ -16,7 +17,7 @@ export function TagList({ items, maxDisplay = 2, variant = 'secondary', size = '
   const textSizeClass = size === 'sm' ? 'text-[10px]' : 'text-xs';
 
   return (
-    <div className={`flex flex-wrap gap-1 ${className}`}>
+    <div className={cn('flex flex-wrap gap-1', className)}>
       {items.slice(0, maxDisplay).map((item) => (
         <Badge className={textSizeClass} key={item} variant={variant}>
           {item}

--- a/packages/ui/src/textarea.tsx
+++ b/packages/ui/src/textarea.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function Textarea({ className, ...props }: ComponentProps<'textarea'>) {
   return (

--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -1,17 +1,13 @@
 import { Arrow, Content, Portal, Provider, Root, Trigger } from '@radix-ui/react-tooltip';
-import { cn } from '@xbrk/ui';
 import { type ComponentProps } from 'react';
+import { cn } from './lib/cn';
 
 function TooltipProvider({ delayDuration = 0, ...props }: Readonly<ComponentProps<typeof Provider>>) {
   return <Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />;
 }
 
 function Tooltip({ ...props }: Readonly<ComponentProps<typeof Root>>) {
-  return (
-    <TooltipProvider>
-      <Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+  return <Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({ ...props }: Readonly<ComponentProps<typeof Trigger>>) {

--- a/packages/ui/src/zoom-image.tsx
+++ b/packages/ui/src/zoom-image.tsx
@@ -1,4 +1,4 @@
-import ImageZoom from '@xbrk/ui/image-zoom';
+import ImageZoom from './image-zoom';
 import { LazyImage } from './lazy-image';
 
 export default function ZoomImage(props: Readonly<React.ComponentPropsWithoutRef<typeof LazyImage>>) {
@@ -9,7 +9,7 @@ export default function ZoomImage(props: Readonly<React.ComponentPropsWithoutRef
       <ImageZoom>
         <LazyImage alt={alt} className="mt-6 rounded-lg border" {...rest} />
       </ImageZoom>
-      {caption && <figcaption className="mt-4 text-center">{alt}</figcaption>}
+      {caption && <figcaption className="mt-4 text-center">{caption}</figcaption>}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Refactor `@xbrk/ui` for clarity, maintainability, and correctness. This PR removes the package's self-import cycle, fixes several bugs, improves component structure, and enforces consistent import ordering across the monorepo.

---

## Changes

### Phase 1 — Structural improvements

- **Extract `cn` utility** into `src/lib/cn.ts` and re-export from `src/index.ts` — keeps the public API stable while eliminating the self-import cycle.
- **Replace all 42 internal `cn` imports** from `@xbrk/ui` with relative `./lib/cn` paths across all UI components.
- **Extract shared glitch animation CSS** into `src/internal/glitch-styles.ts` — deduplicates ~60 identical lines of CSS that were duplicated across `default-catch-boundary.tsx` and `not-found.tsx`.

### Phase 2 — Bug fixes

| Component | Issue | Fix |
|---|---|---|
| `zoom-image` | `caption` prop was destructured and ignored; `figcaption` always rendered `alt` instead | Render `{caption}` when provided |
| `files` | `className` passed to `cn(item({className}))` was swallowed by CVA as a variant prop instead of being merged | Changed to `cn(item(), className)` |
| `tooltip` | Each `<Tooltip>` created a new `<TooltipProvider>`, causing duplicated event listeners and preventing app-level configuration | Removed auto-provider; callers now place `<TooltipProvider>` at the appropriate scope (shadcn pattern) |
| `loading-skeleton` | `animate-[shimmer_2s_infinite]` referenced `@keyframes shimmer` which was never defined globally — animation was broken | Added inline `<style>` with the keyframe definition |
| `calendar` | `Root`, `Chevron`, and `WeekNumber` components were defined inside JSX, causing React unmount/remount on every render | Extracted to module-level named components |
| `sidebar` | `SidebarMenuSkeleton` used `Math.random()` for width, causing SSR hydration mismatches | Replaced with a deterministic `80%` default; added optional `width` prop |

### Phase 3 — Ref pass-through

- **`code-block`**: The external `ref` prop was destructured but never composed with the internal `textInput` ref. Now composed via a `useCallback` ref callback so both the consumer and internal logic receive the DOM node.

### Phase 4 — Consistency

- **`tag-list`**: Converted template literal class concatenation to `cn()` for consistency with the rest of the codebase.

### TooltipProvider scoping

- **Added `TooltipProvider` at the shell level** in both `apps/web/src/routes/__root.tsx` and `apps/dashboard/src/routes/__root.tsx`. This matches the [shadcn/ui pattern](https://ui.shadcn.com/docs/components/tooltip) where a single provider wraps the entire app tree.
- **Reverted** the per-component `TooltipProvider` wrapper in `experience-entry.tsx` — unnecessary now that the root-level provider handles it.

### Code style

- Applied `biome check --write` across the monorepo to enforce consistent import ordering.

---

## Breaking change

`Tooltip` no longer self-wraps in `<TooltipProvider>`. Consumers must provide their own `<TooltipProvider>` at an appropriate level. Both `apps/web` and `apps/dashboard` were updated with root-level providers in this PR.

---

## Verification

- [x] TypeScript typecheck passes (`pnpm --filter @xbrk/ui run typecheck`)
- [x] Biome check passes on all changed files
- [x] Branch: `refactor/ui`
