### PR TITLE
CI, Turbo, CodeQL, and repo hygiene improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       
-      - name: Run Turbo (Build, Lint, Typecheck)
-        run: pnpm turbo run build lint typecheck
+      - name: Run quality gates
+        run: |
+          pnpm check
+          pnpm typecheck
+          pnpm test
+          pnpm build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,6 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['javascript', 'typescript']
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -56,13 +51,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: ${{ matrix.language }}
+          languages: javascript-typescript
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+      - name: Build
+        run: pnpm build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,18 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".output/**", "dist/**"]
+      "outputs": [".output/**", "dist/**"],
+      "inputs": [
+        "src/**",
+        "tsconfig.json",
+        "package.json",
+        "!dist/**",
+        "!.output/**",
+        "!.cache/**",
+        "!coverage/**",
+        "!node_modules/.vite/**",
+        "!routeTree.gen.ts"
+      ]
     },
     "dev": {
       "cache": false,
@@ -21,18 +32,28 @@
     "db:studio": {
       "cache": false
     },
-    "lint": {
-      "inputs": ["**/*.{ts,tsx,js,jsx,json,css}"]
+    "db:generate": {
+      "cache": false
     },
-    "format": {
-      "inputs": ["**/*.{ts,tsx,js,jsx,json,css,md}"]
+    "db:migrate": {
+      "cache": false
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["^typecheck"],
+      "inputs": [
+        "src/**",
+        "tsconfig.json",
+        "!dist/**",
+        "!.output/**",
+        "!.cache/**",
+        "!coverage/**",
+        "!node_modules/.vite/**",
+        "!routeTree.gen.ts"
+      ]
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "outputs": []
     },
     "test:watch": {
       "cache": false,


### PR DESCRIPTION
## Summary

This PR overhauls the monorepo's CI pipeline, Turbo task graph, CodeQL scanning, and repo-level formatting enforcement. The changes eliminate false-positive task notifications, reduce cache noise from generated artifacts, and align CI gates with the actual developer workflow.

## Changes

### CI Correctness (`.github/workflows/ci.yml`)
- Replaced `pnpm turbo run build lint typecheck` with explicit quality gates: `pnpm check`, `pnpm typecheck`, `pnpm test`, `pnpm build`
- Added `pnpm test` to CI — the test suite was previously never run in CI
- `pnpm check` invokes `biome check .` directly (the old Turbo `lint` target doesn't exist in packages, producing 22 "not found" warnings)

### Turbo Graph Cleanup (`turbo.json`)
- **Removed `lint` and `format` tasks** — these are root-level Biome commands, not per-package scripts; Turbo was scheduling 22 nonexistent tasks
- **Added `inputs` with exclusion patterns** to `build` and `typecheck` — generated directories (`dist/`, `.output/`, `.cache/`, `coverage/`, `node_modules/.vite/`, `routeTree.gen.ts`) no longer invalidate cache keys
- **Changed `test.outputs` from `["coverage/**"]` to `[]`** — coverage is not produced by `vitest run` (no `--coverage` flag), so Turbo was expecting output files that don't exist
- **Added `db:generate` and `db:migrate` as uncached tasks** — these were missing from turbo.json

### CodeQL Simplification (`.github/workflows/codeql.yml`)
- **Removed `javascript`/`typescript` matrix** — replaced with a single `javascript-typescript` language target
- **Replaced `autobuild` with `pnpm build`** — deterministic build using the real pipeline instead of CodeQL's heuristic autobuild
- Added explicit `pnpm install --frozen-lockfile` step

### Line-Ending Enforcement & Schema Fix
- **Added `.gitattributes`** with `* text=auto eol=lf` — enforces LF line endings repo-wide, matching `.editorconfig`, preventing CRLF noise in Biome diffs
- **Fixed Biome schema URL** — changed from local `./node_modules/...` to `https://biomejs.dev/schemas/2.4/schema.json`
