### PR TITLE
fix: include env vars and config files in Turbo build cache key

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -8,12 +8,23 @@
         "src/**",
         "tsconfig.json",
         "package.json",
+        "vite.config.*",
+        "nitro.config.*",
+        "public/**",
         "!dist/**",
         "!.output/**",
         "!.cache/**",
         "!coverage/**",
         "!node_modules/.vite/**",
-        "!routeTree.gen.ts"
+        "!src/routeTree.gen.ts"
+      ],
+      "env": [
+        "CI",
+        "VERCEL",
+        "NODE_ENV",
+        "SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Summary

Extends the Turbo `build` task cache key to account for environment variables that affect the Vite build output. Without this, local, CI, and Vercel builds can share cached results despite producing different bundles.

## Changes

### `turbo.json` — `build` task

- **Added `vite.config.*`, `nitro.config.*`, `public/**` to `inputs`** — config file and static asset changes now properly bust the cache
- **Fixed exclusion path** — `!routeTree.gen.ts` → `!src/routeTree.gen.ts` (the generated file lives in a subdirectory)
- **Added `env` array** with six keys:
  - `CI` / `VERCEL` — control `isProductionBuild` and the Nitro `preset`
  - `NODE_ENV` — controls `enableDevtools` (devtools are included in dev, excluded in production builds)
  - `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` — control `enableSentry` and sourcemap generation
